### PR TITLE
Add ids to switch elements

### DIFF
--- a/src/components/ModalRosterTable.js
+++ b/src/components/ModalRosterTable.js
@@ -179,6 +179,7 @@ export function ModalRosterTable({
               <h6 className="ms-auto mt-3">
                 <Form.Check
                   type="switch"
+                  id="switch-roster-show-army-bonus"
                   label="Show Army Bonus"
                   checked={showArmyBonus}
                   onChange={handleBonusToggle}
@@ -187,6 +188,7 @@ export function ModalRosterTable({
               <h6 className="ms-2 me-3 mt-3">
                 <Form.Check
                   type="switch"
+                  id="switch-roster-text-print-view"
                   label="Text Print View"
                   checked={textView}
                   onChange={handleTextToggle}

--- a/src/components/OptionHero.js
+++ b/src/components/OptionHero.js
@@ -222,6 +222,7 @@ export function OptionHero({
         :
         <Form.Check
         type="switch"
+        id={"switch-" + unit.id + "-" + option.option.replaceAll(" ", "-")}
         label={option.option + " (" + option.points + " points)"}
         checked={option.opt_quantity === 1}
         disabled={option.min === option.max}

--- a/src/components/OptionWarrior.js
+++ b/src/components/OptionWarrior.js
@@ -179,6 +179,7 @@ export function OptionWarrior({
       {option.option + " (" + option.points + " points)"}
     </Stack> : <Form.Check
       type="switch"
+      id={"switch-" + unit.id + "-" + option.option.replaceAll(" ", "-")}
       label={option.option + " (" + option.points + " points)"}
       checked={option.opt_quantity === 1}
       disabled={(option.min === option.max) || !roster.warbands[warbandNum - 1].hero || (option.type === "special_warband_upgrade" && !hero_constraint_data[roster.warbands[warbandNum - 1].hero.model_id][0]['special_warband_options'].includes(option.option)) || (option.type === "special_army_upgrade" && !specialArmyOptions.includes(option.option))}

--- a/src/components/WarbandHero.js
+++ b/src/components/WarbandHero.js
@@ -120,6 +120,7 @@ export function WarbandHero({
                 reverse
                 className={roster['leader_warband_num'] === warbandNum ? "text-success" : ""}
                 type="switch"
+                id={"switch-" + unitData.id + "-leader"}
                 label="Leader"
                 name="leader"
                 checked={roster["leader_warband_num"] === warbandNum}


### PR DESCRIPTION
This lets the component set the `for` attribute on the `Label` element, which in turn allows the user to click on the label to control the checkbox, which is an expected behaviour.

Roster table modals have static ids
Unit option switches incorporate `unit.id` and the option name for a messy but unique id

**Disclaimer:** I'm primarily neither a js developer nor a front-ender, so apologies if either the concept or the execution are wrong... 😅