### PR TITLE
Ensure that the application runs under a subpath of /mesbg-list-builder

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/mesbg-list-builder/",
   plugins: [react()],
   server: {
     port: 3000


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9e26a6d2-cf53-4b9d-9c7e-94246444ea43)

This MR ensures that the assets get the /mesbg-list-builder prefix to ensure they load on the github page. 