### PR TITLE
Version management from package & configfuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+message="Update version to v%s"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@types/node": "^22.4.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@types/uuid": "^10.0.0",
@@ -1247,6 +1248,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
+      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -5397,6 +5407,12 @@
       "peerDependencies": {
         "react": ">=15.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@types/node": "^22.4.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/uuid": "^10.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import faction_data from "./assets/data/faction_data.json";
 import { ModalRosterTable } from "./components/ModalRosterTable";
 import { ModalImportJSON } from "./components/ModalImportJSON";
 import { ModalProfileCard } from "./components/ModalProfileCard";
-import { TopNavbar, VERSION } from "./components/TopNavbar";
+import { TopNavbar } from "./components/TopNavbar";
 import { Alliances, calculateAllianceLevel } from "./components/Alliances";
 import { SelectionMenu } from "./components/SelectionMenu.jsx";
 import { Warbands } from "./components/Warbands";
@@ -42,7 +42,7 @@ export default function App() {
   const [warbandNumFocus, setWarbandNumFocus] = useState(0);
   const [newWarriorFocus, setNewWarriorFocus] = useState("");
   const [roster, setRoster] = useState({
-    version: VERSION,
+    version: BUILD_VERSION,
     num_units: 0,
     points: 0,
     bow_count: 0,

--- a/src/components/GameModeAlert.jsx
+++ b/src/components/GameModeAlert.jsx
@@ -1,12 +1,11 @@
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
-import { VERSION } from "./TopNavbar";
 import { TbRefresh } from "react-icons/tb";
 
 export function GameModeAlert({ gameModeAlert, setGameModeAlert, setRoster }) {
   const handleResetList = () => {
     setRoster({
-      version: VERSION,
+      version: BUILD_VERSION,
       num_units: 0,
       points: 0,
       bow_count: 0,

--- a/src/components/TopNavbar.jsx
+++ b/src/components/TopNavbar.jsx
@@ -12,9 +12,6 @@ import { Navbar } from "react-bootstrap";
 import logo from "../assets/images/logo.svg";
 import title from "../assets/images/title.png";
 
-export const VERSION = "5.3.10";
-const UPDATED = "17-Aug-2024";
-
 /* Navbar component that displays at the top of the page. */
 
 export function TopNavbar({
@@ -80,7 +77,7 @@ export function TopNavbar({
                   <img src={title} alt="" style={{ width: "325px" }} />
                   <Stack direction="horizontal" className="mt-2">
                     <span className="p-0 m-0" style={{ fontSize: "16px" }}>
-                      Unofficial | v{VERSION} | updated {UPDATED}
+                      Unofficial | v{BUILD_VERSION} | updated {BUILD_DATE}
                     </span>
                   </Stack>
                 </Stack>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+declare const BUILD_VERSION: string;
+declare const BUILD_DATE: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,24 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+const currentDate = new Date()
+  .toLocaleDateString("en-UK", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  })
+  .replace(/ /g, "-");
+
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "/mesbg-list-builder/",
   plugins: [react()],
   server: {
     port: 3000,
+  },
+  define: {
+    BUILD_VERSION: JSON.stringify(process.env.npm_package_version),
+    BUILD_DATE: JSON.stringify(currentDate),
   },
   build: {
     outDir: "./build",


### PR DESCRIPTION
# What in this pull request

In this pull request I moved the 2 constants that are used as version and build date to the Vite configuration. These 2 fields feel like application meta data and as such I believe they are supposed to be part of the configuration. 

The values of both of these fields are currently dynamic, but can be set to a fixed value if requested. 

- `BUILD_VERSION` is retrieved from the package.json version. I've also updated this in the Vite migration to match the current application version (so its not showing in the current diffs). This version can be updated manually, but preferable you should use the NPM CLI to do so. Running `npm version <major | minor | patch>` will update the respective part of the version. This will also create a commit & tag to trace back to the moment of the version bump (This can be disabled though).
- `BUILD_DATE` is equal to the moment of starting or building the application. Using `npm start` it displays the current date, though using `npm run build` pre bakes the date of building into that field making sure the build date is always the last date of building the application. 

Please let me know if this is to your liking, or if you want anything to change ;)