### PR TITLE
Make image loading snappy again

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A simple and intuitive tool for building your army lists in Middle-Earth Strateg
 Fully up-to-date with the February 2024 FAQs/Errata. Mobile version not currently supported.
 
 ### Acknowledgements
+
 Special thank you to [@mhollink](https://github.com/mhollink) for his big contributions to the codebase.
 
 ### Feature Highlights:

--- a/src/components/FactionLogo.tsx
+++ b/src/components/FactionLogo.tsx
@@ -1,6 +1,5 @@
 import { CSSProperties, FunctionComponent } from "react";
-
-const DEFAULT_IMAGE = "./assets/images/default.png";
+import { ImageWithFallback } from "./ImageWithFallback.tsx";
 
 type FactionLogoProps = {
   faction: string;
@@ -12,16 +11,11 @@ export const FactionLogo: FunctionComponent<FactionLogoProps> = ({
   faction,
   style,
   className,
-}) => {
-  const imagePath = "./assets/images/faction_logos/" + faction + ".png";
-  return (
-    <object
-      data={imagePath}
-      type="image/png"
-      style={style}
-      className={className}
-    >
-      <img src={DEFAULT_IMAGE} style={style} className={className} alt="" />
-    </object>
-  );
-};
+}) => (
+  <ImageWithFallback
+    source={"./assets/images/faction_logos/" + faction + ".png"}
+    fallbackImageSource="./assets/images/default.png"
+    style={style}
+    className={className}
+  />
+);

--- a/src/components/ImageWithFallback.tsx
+++ b/src/components/ImageWithFallback.tsx
@@ -1,0 +1,38 @@
+import { CSSProperties, FunctionComponent, useState } from "react";
+
+type ImageWithFallbackProps = {
+  source: string;
+  fallbackImageSource: string;
+  alt?: string;
+  style?: CSSProperties | undefined;
+  className?: string;
+};
+
+export const ImageWithFallback: FunctionComponent<ImageWithFallbackProps> = ({
+  source,
+  fallbackImageSource,
+  style,
+  className,
+  alt = "",
+}) => {
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  const onError = (e) => {
+    if (usingFallback) {
+      return;
+    }
+
+    e.currentTarget.src = fallbackImageSource;
+    setUsingFallback(true);
+  };
+
+  return (
+    <img
+      src={source}
+      style={style}
+      className={className}
+      onError={onError}
+      alt={alt}
+    />
+  );
+};

--- a/src/components/UnitProfilePicture.tsx
+++ b/src/components/UnitProfilePicture.tsx
@@ -22,6 +22,7 @@ export const UnitProfilePicture: FunctionComponent<UnitProfilePictureProps> = ({
       fallbackImageSource="./assets/images/default.png"
       style={style}
       className={className}
+      alt={`Profile picture for ${profile}`}
     />
   );
 };
@@ -38,6 +39,7 @@ export const UnitProfileCard: FunctionComponent<UnitProfilePictureProps> = ({
       fallbackImageSource="./assets/images/default_card.jpg"
       style={style}
       className={className}
+      alt={`Profile card for ${profile}`}
     />
   );
 };

--- a/src/components/UnitProfilePicture.tsx
+++ b/src/components/UnitProfilePicture.tsx
@@ -1,6 +1,5 @@
 import { CSSProperties, FunctionComponent } from "react";
-
-const DEFAULT_IMAGE = "./assets/images/default.png";
+import { ImageWithFallback } from "./ImageWithFallback.tsx";
 
 type UnitProfilePictureProps = {
   army: string;
@@ -15,17 +14,15 @@ export const UnitProfilePicture: FunctionComponent<UnitProfilePictureProps> = ({
   style,
   className,
 }) => {
-  const imagePath =
-    "./assets/images/profiles/" + army + "/pictures/" + profile + ".png";
   return (
-    <object
-      data={imagePath}
-      type="image/png"
+    <ImageWithFallback
+      source={
+        "./assets/images/profiles/" + army + "/pictures/" + profile + ".png"
+      }
+      fallbackImageSource="./assets/images/default.png"
       style={style}
       className={className}
-    >
-      <img src={DEFAULT_IMAGE} className={className} style={style} alt="" />
-    </object>
+    />
   );
 };
 
@@ -35,16 +32,12 @@ export const UnitProfileCard: FunctionComponent<UnitProfilePictureProps> = ({
   style,
   className,
 }) => {
-  const imagePath =
-    "./assets/images/profiles/" + army + "/cards/" + profile + ".jpg";
   return (
-    <object
-      className={className}
-      data={imagePath}
-      type="image/png"
+    <ImageWithFallback
+      source={"./assets/images/profiles/" + army + "/cards/" + profile + ".jpg"}
+      fallbackImageSource="./assets/images/default.png"
       style={style}
-    >
-      <img src={DEFAULT_IMAGE} className={className} style={style} alt="" />
-    </object>
+      className={className}
+    />
   );
 };

--- a/src/components/UnitProfilePicture.tsx
+++ b/src/components/UnitProfilePicture.tsx
@@ -35,7 +35,7 @@ export const UnitProfileCard: FunctionComponent<UnitProfilePictureProps> = ({
   return (
     <ImageWithFallback
       source={"./assets/images/profiles/" + army + "/cards/" + profile + ".jpg"}
-      fallbackImageSource="./assets/images/default.png"
+      fallbackImageSource="./assets/images/default_card.jpg"
       style={style}
       className={className}
     />


### PR DESCRIPTION
## Changes

I've removed the `<object>` tags and started using the onError callback to update the source of the image if the initial source could not be found. This way a regualar `<img>` tag is used which loads more snappy than the `<object>`. 