### PR TITLE
Update application store

### DIFF
--- a/src/components/gamemode/types.ts
+++ b/src/components/gamemode/types.ts
@@ -7,9 +7,3 @@ export type GameModeHero = {
   xMWFW: string;
   leader: boolean;
 };
-
-export type GameModeState = {
-  heroes: Record<string, GameModeHero[]>;
-  casualties: number;
-  heroCasualties: number;
-};

--- a/src/state/alert/index.ts
+++ b/src/state/alert/index.ts
@@ -14,6 +14,7 @@ const initialState = {
 export const alertSlice: Slice<AlertState> = (set) => ({
   ...initialState,
 
-  triggerAlert: (alert) => set({ activeAlert: alert }),
-  dismissAlert: () => set({ activeAlert: null }),
+  triggerAlert: (alert) =>
+    set({ activeAlert: alert }, undefined, "TRIGGER_ALERT"),
+  dismissAlert: () => set({ activeAlert: null }, undefined, "DISMISS_ALERT"),
 });

--- a/src/state/alert/index.ts
+++ b/src/state/alert/index.ts
@@ -1,0 +1,19 @@
+import { AlertTypes } from "../../components/alerts/alert-types.tsx";
+import { Slice } from "../store.ts";
+
+export type AlertState = {
+  activeAlert: AlertTypes | null;
+  triggerAlert: (alert: AlertTypes) => void;
+  dismissAlert: () => void;
+};
+
+const initialState = {
+  activeAlert: null,
+};
+
+export const alertSlice: Slice<AlertState> = (set) => ({
+  ...initialState,
+
+  triggerAlert: (alert) => set({ activeAlert: alert }),
+  dismissAlert: () => set({ activeAlert: null }),
+});

--- a/src/state/gamemode/index.ts
+++ b/src/state/gamemode/index.ts
@@ -24,21 +24,29 @@ const initialState = {
 export const gamemodeSlice: Slice<GamemodeState> = (set, get) => ({
   ...initialState,
 
-  setGameMode: (gameMode) => set({ gameMode }),
+  setGameMode: (gameMode) => set({ gameMode }, undefined, "SET_GAME_MODE"),
   startNewGame: () =>
-    set({
-      gameMode: true,
-      gameState: {
-        heroes: getHeroesForGameMode(get().roster),
-        casualties: 0,
-        heroCasualties: 0,
+    set(
+      {
+        gameMode: true,
+        gameState: {
+          heroes: getHeroesForGameMode(get().roster),
+          casualties: 0,
+          heroCasualties: 0,
+        },
       },
-    }),
+      undefined,
+      "START_GAME",
+    ),
   updateGameState: (gameStateUpdate) =>
-    set({
-      gameState: {
-        ...get().gameState,
-        ...gameStateUpdate,
+    set(
+      {
+        gameState: {
+          ...get().gameState,
+          ...gameStateUpdate,
+        },
       },
-    }),
+      undefined,
+      "UPDATE_GAME_STATE",
+    ),
 });

--- a/src/state/gamemode/index.ts
+++ b/src/state/gamemode/index.ts
@@ -1,0 +1,44 @@
+import { GameModeHero } from "../../components/gamemode/types.ts";
+import { Slice } from "../store.ts";
+import { getHeroesForGameMode } from "./gamemode.ts";
+
+export type GameState = {
+  heroes: Record<string, GameModeHero[]>;
+  casualties: number;
+  heroCasualties: number;
+};
+
+export type GamemodeState = {
+  gameMode: boolean;
+  setGameMode: (gameMode: boolean) => void;
+  gameState?: GameState;
+  startNewGame: () => void;
+  updateGameState: (update: Partial<GameState>) => void;
+};
+
+const initialState = {
+  gameMode: false,
+  gameState: null,
+};
+
+export const gamemodeSlice: Slice<GamemodeState> = (set, get) => ({
+  ...initialState,
+
+  setGameMode: (gameMode) => set({ gameMode }),
+  startNewGame: () =>
+    set({
+      gameMode: true,
+      gameState: {
+        heroes: getHeroesForGameMode(get().roster),
+        casualties: 0,
+        heroCasualties: 0,
+      },
+    }),
+  updateGameState: (gameStateUpdate) =>
+    set({
+      gameState: {
+        ...get().gameState,
+        ...gameStateUpdate,
+      },
+    }),
+});

--- a/src/state/modal/index.ts
+++ b/src/state/modal/index.ts
@@ -1,0 +1,29 @@
+import { ModalTypes } from "../../components/modal/modals.tsx";
+import { Slice } from "../store.ts";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ModalContext = any;
+
+export type ModalState = {
+  currentlyOpenendModal: ModalTypes | null;
+  modalContext?: ModalContext;
+  setCurrentModal: (key: ModalTypes, context?: ModalContext) => void;
+  closeModal: () => void;
+};
+
+const initialModalState = {
+  currentlyOpenendModal: null,
+  modalContext: null,
+};
+
+export const modalSlice: Slice<ModalState> = (set) => ({
+  ...initialModalState,
+
+  setCurrentModal: (modal, context) =>
+    set({ currentlyOpenendModal: modal, modalContext: context }),
+  closeModal: () =>
+    set({
+      currentlyOpenendModal: null,
+      modalContext: null,
+    }),
+});

--- a/src/state/modal/index.ts
+++ b/src/state/modal/index.ts
@@ -20,10 +20,18 @@ export const modalSlice: Slice<ModalState> = (set) => ({
   ...initialModalState,
 
   setCurrentModal: (modal, context) =>
-    set({ currentlyOpenendModal: modal, modalContext: context }),
+    set(
+      { currentlyOpenendModal: modal, modalContext: context },
+      undefined,
+      "OPEN_MODAL",
+    ),
   closeModal: () =>
-    set({
-      currentlyOpenendModal: null,
-      modalContext: null,
-    }),
+    set(
+      {
+        currentlyOpenendModal: null,
+        modalContext: null,
+      },
+      undefined,
+      "CLOSE_MODAL",
+    ),
 });

--- a/src/state/persistence.ts
+++ b/src/state/persistence.ts
@@ -1,0 +1,22 @@
+import { AppState } from "./store.ts";
+
+type StoreKey = keyof AppState;
+export const keysToPersist: StoreKey[] = [
+  "roster",
+  "gameMode",
+  "gameState",
+  "factions",
+  "factionType",
+  "factionMetaData",
+  "allianceLevel",
+  "uniqueModels",
+  "rosterBuildingWarnings",
+  "armyBonusActive",
+];
+
+export const getStateToPersist = (state: AppState): Partial<AppState> =>
+  Object.fromEntries(
+    Object.entries(state).filter((stateEntry) =>
+      keysToPersist.includes(stateEntry[0] as StoreKey),
+    ),
+  );

--- a/src/state/roster/index.ts
+++ b/src/state/roster/index.ts
@@ -1,0 +1,44 @@
+import { AllianceLevel } from "../../components/constants/alliances.ts";
+import { Faction, FactionType } from "../../types/factions.ts";
+import { Roster } from "../../types/roster.ts";
+import { Slice } from "../store.ts";
+import { ModelCountData } from "./models.ts";
+import { updateRoster } from "./roster.ts";
+
+export type RosterState = {
+  roster: Roster;
+  setRoster: (roster: Roster) => void;
+  factionType: FactionType | "";
+  factions: Faction[];
+  factionMetaData: ModelCountData;
+  allianceLevel: AllianceLevel;
+  armyBonusActive: boolean;
+  uniqueModels: string[];
+  rosterBuildingWarnings: string[];
+};
+
+const initialState = {
+  roster: {
+    version: BUILD_VERSION,
+    num_units: 0,
+    points: 0,
+    bow_count: 0,
+    warbands: [],
+  },
+  factions: [],
+  factionType: "" as FactionType,
+  factionMetaData: {} as ModelCountData,
+  allianceLevel: "n/a" as AllianceLevel,
+  armyBonusActive: true,
+  uniqueModels: [],
+  rosterBuildingWarnings: [],
+};
+
+export const rosterSlice: Slice<RosterState> = (set) => ({
+  ...initialState,
+
+  setRoster: (roster) =>
+    set({
+      ...updateRoster(roster),
+    }),
+});

--- a/src/state/roster/index.ts
+++ b/src/state/roster/index.ts
@@ -38,7 +38,11 @@ export const rosterSlice: Slice<RosterState> = (set) => ({
   ...initialState,
 
   setRoster: (roster) =>
-    set({
-      ...updateRoster(roster),
-    }),
+    set(
+      {
+        ...updateRoster(roster),
+      },
+      undefined,
+      "SET_ROSTER",
+    ),
 });

--- a/src/state/roster/roster.ts
+++ b/src/state/roster/roster.ts
@@ -1,5 +1,5 @@
 import { Roster } from "../../types/roster.ts";
-import { ListBuilderStore } from "../store.ts";
+import { AppState } from "../store.ts";
 import {
   calculateAllianceLevel,
   checkForSpecialCases,
@@ -9,7 +9,7 @@ import { getFactionList, getFactionType } from "./faction.ts";
 import { calculateModelCount, getUniqueModels } from "./models.ts";
 import { getWarningsForCreatedRoster } from "./warnings.ts";
 
-export function updateRoster(roster: Roster): Partial<ListBuilderStore> {
+export function updateRoster(roster: Roster): Partial<AppState> {
   const factionType = getFactionType(roster.warbands);
   const factionList = getFactionList(roster.warbands);
   const uniqueModels = getUniqueModels(roster.warbands);

--- a/src/state/sidebar/index.ts
+++ b/src/state/sidebar/index.ts
@@ -14,6 +14,8 @@ const initialState = {
 export const sidebarSlice: Slice<SidebarState> = (set) => ({
   ...initialState,
 
-  openSidebar: (sidebar) => set({ currentlyOpenendSidebar: sidebar }),
-  closeSidebar: () => set({ currentlyOpenendSidebar: null }),
+  openSidebar: (sidebar) =>
+    set({ currentlyOpenendSidebar: sidebar }, undefined, "OPEN_SIDEBAR"),
+  closeSidebar: () =>
+    set({ currentlyOpenendSidebar: null }, undefined, "CLOSE_SIDEBAR"),
 });

--- a/src/state/sidebar/index.ts
+++ b/src/state/sidebar/index.ts
@@ -1,0 +1,19 @@
+import { SidebarTypes } from "../../components/sidebar-drawer/sidebars.tsx";
+import { Slice } from "../store.ts";
+
+export type SidebarState = {
+  currentlyOpenendSidebar: SidebarTypes | null;
+  openSidebar: (sidebarType: SidebarTypes) => void;
+  closeSidebar: () => void;
+};
+
+const initialState = {
+  currentlyOpenendSidebar: null,
+};
+
+export const sidebarSlice: Slice<SidebarState> = (set) => ({
+  ...initialState,
+
+  openSidebar: (sidebar) => set({ currentlyOpenendSidebar: sidebar }),
+  closeSidebar: () => set({ currentlyOpenendSidebar: null }),
+});

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { alertSlice, AlertState } from "./alert";
 import { gamemodeSlice, GamemodeState } from "./gamemode";
 import { modalSlice, ModalState } from "./modal";
@@ -17,19 +17,24 @@ export type SliceSet<T> = (state: Partial<T>) => void;
 export type SliceGet = () => AppState;
 export type Slice<T> = (set: SliceSet<T>, get?: SliceGet) => T;
 
-export const useStore = create<AppState, [["zustand/persist", unknown]]>(
-  persist(
-    (set, get) => ({
-      ...modalSlice(set),
-      ...sidebarSlice(set),
-      ...alertSlice(set),
-      ...gamemodeSlice(set, get),
-      ...rosterSlice(set),
-    }),
-    {
-      name: "mesbg-lb-storage",
-      storage: createJSONStorage(() => sessionStorage),
-      partialize: (state) => getStateToPersist(state),
-    },
+export const useStore = create<
+  AppState,
+  [["zustand/devtools", unknown], ["zustand/persist", unknown]]
+>(
+  devtools(
+    persist(
+      (set, get) => ({
+        ...modalSlice(set),
+        ...sidebarSlice(set),
+        ...alertSlice(set),
+        ...gamemodeSlice(set, get),
+        ...rosterSlice(set),
+      }),
+      {
+        name: "mesbg-lb-storage",
+        storage: createJSONStorage(() => sessionStorage),
+        partialize: (state) => getStateToPersist(state),
+      },
+    ),
   ),
 );

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -3,6 +3,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { alertSlice, AlertState } from "./alert";
 import { gamemodeSlice, GamemodeState } from "./gamemode";
 import { modalSlice, ModalState } from "./modal";
+import { getStateToPersist } from "./persistence.ts";
 import { rosterSlice, RosterState } from "./roster";
 import { sidebarSlice, SidebarState } from "./sidebar";
 
@@ -16,20 +17,6 @@ export type SliceSet<T> = (state: Partial<T>) => void;
 export type SliceGet = () => AppState;
 export type Slice<T> = (set: SliceSet<T>, get?: SliceGet) => T;
 
-type StoreKey = keyof AppState;
-const keysToPersist: StoreKey[] = [
-  "roster",
-  "gameMode",
-  "gameState",
-  "factions",
-  "factionType",
-  "factionMetaData",
-  "allianceLevel",
-  "uniqueModels",
-  "rosterBuildingWarnings",
-  "armyBonusActive",
-];
-
 export const useStore = create<AppState, [["zustand/persist", unknown]]>(
   persist(
     (set, get) => ({
@@ -42,12 +29,7 @@ export const useStore = create<AppState, [["zustand/persist", unknown]]>(
     {
       name: "mesbg-lb-storage",
       storage: createJSONStorage(() => sessionStorage),
-      partialize: (state) =>
-        Object.fromEntries(
-          Object.entries(state).filter((stateEntry) =>
-            keysToPersist.includes(stateEntry[0] as StoreKey),
-          ),
-        ),
+      partialize: (state) => getStateToPersist(state),
     },
   ),
 );

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -14,8 +14,10 @@ export type AppState = RosterState &
   AlertState;
 
 export type Slice<T> = StateCreator<
-  T,
-  [["zustand/devtools", unknown], ["zustand/persist", unknown]]
+  AppState,
+  [["zustand/devtools", unknown], ["zustand/persist", unknown]],
+  [],
+  T
 >;
 
 export const useStore = create<

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, StateCreator } from "zustand";
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { alertSlice, AlertState } from "./alert";
 import { gamemodeSlice, GamemodeState } from "./gamemode";
@@ -13,9 +13,10 @@ export type AppState = RosterState &
   SidebarState &
   AlertState;
 
-export type SliceSet<T> = (state: Partial<T>) => void;
-export type SliceGet = () => AppState;
-export type Slice<T> = (set: SliceSet<T>, get?: SliceGet) => T;
+export type Slice<T> = StateCreator<
+  T,
+  [["zustand/devtools", unknown], ["zustand/persist", unknown]]
+>;
 
 export const useStore = create<
   AppState,
@@ -23,12 +24,12 @@ export const useStore = create<
 >(
   devtools(
     persist(
-      (set, get) => ({
-        ...modalSlice(set),
-        ...sidebarSlice(set),
-        ...alertSlice(set),
-        ...gamemodeSlice(set, get),
-        ...rosterSlice(set),
+      (...args) => ({
+        ...modalSlice(...args),
+        ...sidebarSlice(...args),
+        ...alertSlice(...args),
+        ...gamemodeSlice(...args),
+        ...rosterSlice(...args),
       }),
       {
         name: "mesbg-lb-storage",

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,71 +1,22 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import { AlertTypes } from "../components/alerts/alert-types.tsx";
-import { AllianceLevel } from "../components/constants/alliances.ts";
-import { GameModeState } from "../components/gamemode/types.ts";
-import { ModalTypes } from "../components/modal/modals.tsx";
-import { SidebarTypes } from "../components/sidebar-drawer/sidebars.tsx";
-import { Faction, FactionType } from "../types/factions.ts";
-import { Roster } from "../types/roster.ts";
-import { getHeroesForGameMode } from "./gamemode/gamemode.ts";
-import { ModelCountData } from "./roster/models.ts";
-import { updateRoster } from "./roster/roster.ts";
+import { alertSlice, AlertState } from "./alert";
+import { gamemodeSlice, GamemodeState } from "./gamemode";
+import { modalSlice, ModalState } from "./modal";
+import { rosterSlice, RosterState } from "./roster";
+import { sidebarSlice, SidebarState } from "./sidebar";
 
-export type ListBuilderStore = {
-  // Roster Building
-  roster: Roster;
-  setRoster: (roster: Roster) => void;
-  factionType: FactionType | "";
-  factions: Faction[];
-  factionMetaData: ModelCountData;
-  allianceLevel: AllianceLevel;
-  armyBonusActive: boolean;
-  uniqueModels: string[];
-  rosterBuildingWarnings: string[];
-  // Game mode
-  gameMode: boolean;
-  setGameMode: (gameMode: boolean) => void;
-  gameState?: GameModeState;
-  startNewGame: () => void;
-  updateGameState: (update: Partial<GameModeState>) => void;
-  // Modals
-  currentlyOpenendModal: ModalTypes | null;
-  modalContext?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  setCurrentModal: (key: ModalTypes, context?: unknown) => void;
-  closeModal: () => void;
-  // Sidebar
-  currentlyOpenendSidebar: SidebarTypes | null;
-  openSidebar: (sidebarType: SidebarTypes) => void;
-  closeSidebar: () => void;
-  // Alerts
-  activeAlert: AlertTypes | null;
-  triggerAlert: (alert: AlertTypes) => void;
-  dismissAlert: () => void;
-};
+export type AppState = RosterState &
+  GamemodeState &
+  ModalState &
+  SidebarState &
+  AlertState;
 
-const initialState = {
-  roster: {
-    version: BUILD_VERSION,
-    num_units: 0,
-    points: 0,
-    bow_count: 0,
-    warbands: [],
-  },
-  factions: [],
-  factionType: "" as FactionType,
-  factionMetaData: {} as ModelCountData,
-  allianceLevel: "n/a" as AllianceLevel,
-  armyBonusActive: true,
-  uniqueModels: [],
-  rosterBuildingWarnings: [],
-  gameMode: false,
-  gameState: undefined,
-  currentlyOpenendModal: null,
-  currentlyOpenendSidebar: null,
-  activeAlert: null,
-};
+export type SliceSet<T> = (state: Partial<T>) => void;
+export type SliceGet = () => AppState;
+export type Slice<T> = (set: SliceSet<T>, get?: SliceGet) => T;
 
-type StoreKey = keyof ListBuilderStore;
+type StoreKey = keyof AppState;
 const keysToPersist: StoreKey[] = [
   "roster",
   "gameMode",
@@ -79,47 +30,14 @@ const keysToPersist: StoreKey[] = [
   "armyBonusActive",
 ];
 
-export const useStore = create<
-  ListBuilderStore,
-  [["zustand/persist", unknown]]
->(
+export const useStore = create<AppState, [["zustand/persist", unknown]]>(
   persist(
     (set, get) => ({
-      ...initialState,
-      setRoster: (roster) =>
-        set({
-          ...updateRoster(roster),
-        }),
-      setGameMode: (gameMode) => set({ gameMode }),
-      startNewGame: () =>
-        set({
-          gameMode: true,
-          gameState: {
-            heroes: getHeroesForGameMode(get().roster),
-            casualties: 0,
-            heroCasualties: 0,
-          },
-        }),
-      updateGameState: (gameStateUpdate) =>
-        set({
-          gameState: {
-            ...get().gameState,
-            ...gameStateUpdate,
-          },
-        }),
-
-      setCurrentModal: (modal, context) =>
-        set({ currentlyOpenendModal: modal, modalContext: context }),
-      closeModal: () =>
-        set({
-          currentlyOpenendModal: null,
-          modalContext: null,
-        }),
-      openSidebar: (sidebar) => set({ currentlyOpenendSidebar: sidebar }),
-      closeSidebar: () => set({ currentlyOpenendSidebar: null }),
-
-      triggerAlert: (alert) => set({ activeAlert: alert }),
-      dismissAlert: () => set({ activeAlert: null }),
+      ...modalSlice(set),
+      ...sidebarSlice(set),
+      ...alertSlice(set),
+      ...gamemodeSlice(set, get),
+      ...rosterSlice(set),
     }),
     {
       name: "mesbg-lb-storage",


### PR DESCRIPTION
## This PR

This pull request changes the file structure of the store and slices the store in their appropriate parts. This means there modal state is no longer mingled in with the roster state and game state. Each of the state parts have their own folder with its appropriate initial state and update functions.

### Extras

- I've also created a file for the persistence of the state, this makes the `store.ts` file even lighter and it is now only used to aggregate the application state. 
- I've added in the zustand devtools which work perfectly together with the Redux Devtools extention
-- [Redux Devtools chrome extention](https://chromewebstore.google.com/detail/lmhkpmbekcpmknklioeibfkpmmfibljd)
-- [Redux Devtools firefox addon](https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/)


**Redux Devtools**
The Redux Devtools allow us the traverse and debug state and see what changed in the state with a certain action on the page.

State graph:
![State graph](https://github.com/user-attachments/assets/5c18b637-9313-41ef-bc48-dcc9560f67f4)

State diff after entering game mode:
![State diff after entering game mode](https://github.com/user-attachments/assets/331dc6d3-00e4-4100-9f06-153f4bbb2ac1)
