### PR TITLE
Disable automatic scrolling for sticky sidebar 

### DIFF
--- a/src/components/common/sidebar/unit-selection/UnitSelector.tsx
+++ b/src/components/common/sidebar/unit-selection/UnitSelector.tsx
@@ -68,6 +68,8 @@ export const UnitSelector = () => {
   };
 
   useEffect(() => {
+    if (!isMobile) return;
+
     window.scrollTo({
       behavior: "smooth",
       top: 0,


### PR DESCRIPTION
Scrolling the page content from bottom to top and back is not necessary if the sidebar is sticky on the side. It however is still useful when the roster selection is stacked ontop of the warbands (in tablet and mobile views).

This PR disables scrolling for views above Tablet size.  