### PR TITLE
Added the selected options to collapsed warband warriors.

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
   "main": {
+    "added": [
+      "Collapsed warriors now display the options selected for each unit."
+    ],
     "bugfixes": [
       "Fixed an issue where a Captain of Carn Dum could only be added once to your army.",
       "Alerts no longer appear behind modal backdrops.",

--- a/src/components/builder-mode/warrior/WarbandWarrior.tsx
+++ b/src/components/builder-mode/warrior/WarbandWarrior.tsx
@@ -26,6 +26,14 @@ export const WarbandWarrior: FunctionComponent<WarbandWarriorProps> = (
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const isTablet = useMediaQuery(theme.breakpoints.down("md"));
+  const optionsString = unit.options
+    .filter((o) => o.opt_quantity)
+    .map((o) => o.option)
+    .join(", ")
+    // replaces the last `,` with an &-sign
+    .replace(/,(?=[^,]*$)/, " &")
+    // surround the string with [] (if there is at least 1 option.)
+    .replace(/^(.+)$/, "[$1]");
   return (
     <Card sx={{ p: 1 }} elevation={2}>
       <Stack
@@ -83,12 +91,22 @@ export const WarbandWarrior: FunctionComponent<WarbandWarriorProps> = (
             spacing={isMobile ? 0 : 3}
             alignItems="center"
           >
-            <Typography variant="body1" component="div" flexGrow={1}>
+            <Typography
+              variant="body1"
+              component="div"
+              flexGrow={1}
+              textAlign={isMobile ? "center" : "start"}
+            >
+              <b>{unit.name} </b>
+              {props.collapsed && !isTablet && <i>{optionsString}</i>}
               <b>
-                {unit.name}{" "}
-                {unit.unit_type === "Warrior" && "(x" + unit.quantity + ")"}
+                {unit.unit_type === "Warrior" && " (x" + unit.quantity + ")"}
               </b>
+              <Typography>
+                {props.collapsed && isTablet && <i>{optionsString}</i>}
+              </Typography>
             </Typography>
+
             <Typography sx={{ paddingRight: "10px" }}>
               Points: <b>{unit.pointsTotal}</b>
               {unit.unit_type === "Warrior" &&


### PR DESCRIPTION
I've added the selected warrior options as an _italic_ text to the collapsed warriors for all screen sizes. There is some wrapping when selecting many options or options with long names. 

resolves #67 

See some screenshots below for impression;

![image](https://github.com/user-attachments/assets/c42beee0-6272-4baa-84ca-e6b19d7a9756)
_Big screen_

![image](https://github.com/user-attachments/assets/9b9ae7c3-519e-474d-9f68-5610836922af)
_Tablet size_

![image](https://github.com/user-attachments/assets/e53bf6ca-3091-47df-8a09-64ce3869477b)
_Mobile size (360x800)_

