### PR TITLE
Refactor modal, alert and sidebar state into seperate (not persisted) store

### DIFF
--- a/src/components/alerts/Alerts.tsx
+++ b/src/components/alerts/Alerts.tsx
@@ -2,11 +2,11 @@ import { AlertColor, Portal, Slide, Snackbar } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import { useEffect } from "react";
-import { useStore } from "../../state/store.ts";
+import { useAppState } from "../../state/app";
 import { alertMap } from "./alert-types.tsx";
 
 export const Alerts = () => {
-  const { activeAlert, dismissAlert } = useStore();
+  const { activeAlert, dismissAlert } = useAppState();
 
   // Auto hide of alerts, if configured
   useEffect(() => {

--- a/src/components/alerts/alerts/GameModeAlert.tsx
+++ b/src/components/alerts/alerts/GameModeAlert.tsx
@@ -2,10 +2,12 @@ import { Refresh } from "@mui/icons-material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { Fragment } from "react";
+import { useAppState } from "../../../state/app";
 import { useStore } from "../../../state/store";
 
 export const GameModeAlert = () => {
-  const { setRoster, dismissAlert } = useStore();
+  const { setRoster } = useStore();
+  const { dismissAlert } = useAppState();
 
   const handleResetList = () => {
     setRoster({

--- a/src/components/builder-mode/BuilderMode.tsx
+++ b/src/components/builder-mode/BuilderMode.tsx
@@ -4,6 +4,7 @@ import ShareIcon from "@mui/icons-material/Share";
 import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useDownload } from "../../hooks/download.ts";
+import { useAppState } from "../../state/app";
 import { useStore } from "../../state/store.ts";
 import { ModalTypes } from "../modal/modals.tsx";
 import { Warbands } from "./warbands/Warbands.tsx";
@@ -12,7 +13,8 @@ export const BuilderMode = () => {
   const [fabBottom, setFabBottom] = useState("16px");
   const [fabOpen, setFabOpen] = useState(false);
   const { downloadProfileCards } = useDownload();
-  const { roster, setCurrentModal } = useStore();
+  const { roster } = useStore();
+  const { setCurrentModal } = useAppState();
 
   const updateFabBottom = () => {
     const footerRect = document

--- a/src/components/builder-mode/hero/HeroActions.tsx
+++ b/src/components/builder-mode/hero/HeroActions.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { FunctionComponent, MouseEventHandler } from "react";
 import { BsFillPersonVcardFill } from "react-icons/bs";
+import { useAppState } from "../../../state/app";
 import { useStore } from "../../../state/store.ts";
 import { Unit } from "../../../types/unit.ts";
 import { ModalTypes } from "../../modal/modals.tsx";
@@ -18,7 +19,8 @@ export const HeroActions: FunctionComponent<HeroActionsProps> = ({
   unit,
   warbandId,
 }) => {
-  const { setCurrentModal, deleteHero } = useStore();
+  const { deleteHero } = useStore();
+  const { setCurrentModal } = useAppState();
   const { palette, breakpoints } = useTheme();
   const isMobile = useMediaQuery(breakpoints.down("sm"));
 

--- a/src/components/builder-mode/unit-selection/selection-list/UnitSelectionButton.tsx
+++ b/src/components/builder-mode/unit-selection/selection-list/UnitSelectionButton.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "@mui/material/styles";
 import { BsFillPersonVcardFill } from "react-icons/bs";
 import { v4 as uuid } from "uuid";
 import { useScrollToElement } from "../../../../hooks/scroll-to.ts";
+import { useAppState } from "../../../../state/app";
 import { useStore } from "../../../../state/store.ts";
 import { Unit } from "../../../../types/unit.ts";
 import { UnitProfilePicture } from "../../../common/images/UnitProfilePicture.tsx";
@@ -15,13 +16,14 @@ import { ModalTypes } from "../../../modal/modals.tsx";
 
 export function UnitSelectionButton({ unitData }: { unitData: Unit }) {
   const {
-    setCurrentModal,
     selectUnit,
     warriorSelectionFocus,
     heroSelection,
     updateBuilderSidebar,
     assignHeroToWarband,
   } = useStore();
+  const { setCurrentModal } = useAppState();
+
   const [focusedWarbandId, focusedUnitId] = warriorSelectionFocus;
   const { palette } = useTheme();
   const scrollTo = useScrollToElement();

--- a/src/components/builder-mode/warrior/WarriorActions.tsx
+++ b/src/components/builder-mode/warrior/WarriorActions.tsx
@@ -14,6 +14,7 @@ import {
   useScrollToElement,
   useScrollToTop,
 } from "../../../hooks/scroll-to.ts";
+import { useAppState } from "../../../state/app";
 import { useStore } from "../../../state/store.ts";
 import { isDefinedUnit, Unit } from "../../../types/unit.ts";
 import { ModalTypes } from "../../modal/modals.tsx";
@@ -92,11 +93,12 @@ export const WarriorActions = ({
   const {
     roster,
     factionSelection,
-    setCurrentModal,
     deleteUnit,
     duplicateUnit,
     updateBuilderSidebar,
   } = useStore();
+  const { setCurrentModal } = useAppState();
+
   const { palette, breakpoints } = useTheme();
   const isMobile = useMediaQuery(breakpoints.down("sm"));
   const scrollTo = useScrollToElement();

--- a/src/components/common/layout/Footer.tsx
+++ b/src/components/common/layout/Footer.tsx
@@ -1,10 +1,10 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import { useStore } from "../../../state/store.ts";
+import { useAppState } from "../../../state/app";
 import { DrawerTypes } from "../../drawer/drawers.tsx";
 
 export const Footer = () => {
-  const { openSidebar } = useStore();
+  const { openSidebar } = useAppState();
   return (
     <Box
       id="footer"

--- a/src/components/common/layout/Header.tsx
+++ b/src/components/common/layout/Header.tsx
@@ -22,6 +22,7 @@ import { Fragment, useState } from "react";
 import logo from "../../../assets/images/logo.svg";
 import title from "../../../assets/images/title.png";
 import { useScrollToTop } from "../../../hooks/scroll-to.ts";
+import { useAppState } from "../../../state/app";
 import { useStore } from "../../../state/store.ts";
 import { isDefinedUnit } from "../../../types/unit.ts";
 import { AlertTypes } from "../../alerts/alert-types.tsx";
@@ -78,14 +79,8 @@ export const Header = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
   const [drawerOpen, setDrawerOpen] = useState(false);
   const scrollToTop = useScrollToTop();
-  const {
-    gameMode,
-    roster,
-    setCurrentModal,
-    triggerAlert,
-    openSidebar,
-    startNewGame,
-  } = useStore();
+  const { gameMode, roster, startNewGame } = useStore();
+  const { setCurrentModal, triggerAlert, openSidebar } = useAppState();
 
   const handleDrawerToggle = () => {
     setDrawerOpen(!drawerOpen);

--- a/src/components/common/sidebar/roster-info/sections/Alliances.tsx
+++ b/src/components/common/sidebar/roster-info/sections/Alliances.tsx
@@ -7,18 +7,19 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { LuSwords } from "react-icons/lu";
 import { allianceColours } from "../../../../../constants/alliances.ts";
+import { useAppState } from "../../../../../state/app";
 import { useStore } from "../../../../../state/store.ts";
 import { DrawerTypes } from "../../../../drawer/drawers.tsx";
 import { ChartsDropdown } from "./ChartsDropdown.tsx";
 
 export const Alliance = () => {
   const {
-    openSidebar,
     factions: factionList,
     allianceLevel,
     factionType,
     gameMode,
   } = useStore();
+  const { openSidebar } = useAppState();
 
   const theme = useTheme();
   const isMobileScreen = useMediaQuery(theme.breakpoints.down("sm"));

--- a/src/components/common/sidebar/roster-info/sections/ChartsDropdown.tsx
+++ b/src/components/common/sidebar/roster-info/sections/ChartsDropdown.tsx
@@ -3,7 +3,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { MouseEvent, useState } from "react";
 import { GiSwordsEmblem } from "react-icons/gi";
-import { useStore } from "../../../../../state/store.ts";
+import { useAppState } from "../../../../../state/app";
 import { ModalTypes } from "../../../../modal/modals.tsx";
 
 const charts: Record<string, string> = {
@@ -23,7 +23,7 @@ const charts: Record<string, string> = {
 };
 
 export const ChartsDropdown = () => {
-  const { setCurrentModal } = useStore();
+  const { setCurrentModal } = useAppState();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);

--- a/src/components/drawer/DrawerContainer.tsx
+++ b/src/components/drawer/DrawerContainer.tsx
@@ -5,11 +5,11 @@ import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
-import { useStore } from "../../state/store.ts";
+import { useAppState } from "../../state/app";
 import { drawers } from "./drawers.tsx";
 
 export const DrawerContainer = () => {
-  const state = useStore();
+  const state = useAppState();
   const { palette } = useTheme();
 
   return [...drawers.entries()].map(([type, props]) => {

--- a/src/components/gamemode/GameMode.tsx
+++ b/src/components/gamemode/GameMode.tsx
@@ -6,6 +6,7 @@ import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useEffect } from "react";
+import { useAppState } from "../../state/app";
 import { useStore } from "../../state/store.ts";
 import { ModalTypes } from "../modal/modals.tsx";
 import { Casualties } from "./Casualties.tsx";
@@ -13,7 +14,8 @@ import { ProfileCards } from "./ProfileCards.tsx";
 import { HeroStatTrackers } from "./hero/HeroStatTrackers";
 
 export const GameMode = () => {
-  const { startNewGame, setCurrentModal } = useStore();
+  const { startNewGame } = useStore();
+  const { setCurrentModal } = useAppState();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const isMediumScreen = useMediaQuery(theme.breakpoints.between("lg", "xl"));

--- a/src/components/modal/ModalContainer.tsx
+++ b/src/components/modal/ModalContainer.tsx
@@ -6,7 +6,7 @@ import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { useStore } from "../../state/store.ts";
+import { useAppState } from "../../state/app";
 import { modals } from "./modals.tsx";
 
 const style = {
@@ -20,7 +20,7 @@ const style = {
 };
 
 export const ModalContainer = () => {
-  const state = useStore();
+  const state = useAppState();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 

--- a/src/components/modal/modals/BuilderModeModal.tsx
+++ b/src/components/modal/modals/BuilderModeModal.tsx
@@ -1,9 +1,11 @@
-import { DialogActions, DialogContent, Button } from "@mui/material";
+import { Button, DialogActions, DialogContent } from "@mui/material";
 import { useScrollToTop } from "../../../hooks/scroll-to.ts";
+import { useAppState } from "../../../state/app";
 import { useStore } from "../../../state/store";
 
 export const BuilderModeModal = () => {
-  const { setGameMode, closeModal } = useStore();
+  const { setGameMode } = useStore();
+  const { closeModal } = useAppState();
   const scrollToTop = useScrollToTop();
 
   const handleContinue = () => {

--- a/src/components/modal/modals/ChartsModal.tsx
+++ b/src/components/modal/modals/ChartsModal.tsx
@@ -1,10 +1,10 @@
 import { DialogContent } from "@mui/material";
-import { useStore } from "../../../state/store.ts";
+import { useAppState } from "../../../state/app";
 
 export function ChartsModal() {
   const {
     modalContext: { selectedChart },
-  } = useStore();
+  } = useAppState();
 
   return (
     <DialogContent>

--- a/src/components/modal/modals/ExportRosterModal.tsx
+++ b/src/components/modal/modals/ExportRosterModal.tsx
@@ -9,10 +9,10 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 import { useExternalStorage } from "../../../hooks/external-storage.ts";
-import { useStore } from "../../../state/store";
+import { useAppState } from "../../../state/app";
 
 export const ExportRosterModal = () => {
-  const { closeModal } = useStore();
+  const { closeModal } = useAppState();
   const { exportRoster, copyToClipboard } = useExternalStorage();
 
   const [filename, setFilename] = useState("");

--- a/src/components/modal/modals/ImportRosterModal.tsx
+++ b/src/components/modal/modals/ImportRosterModal.tsx
@@ -13,10 +13,10 @@ import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useState } from "react";
 import { useExternalStorage } from "../../../hooks/external-storage.ts";
-import { useStore } from "../../../state/store";
+import { useAppState } from "../../../state/app";
 
 export const ImportRosterModal = () => {
-  const { closeModal } = useStore();
+  const { closeModal } = useAppState();
   const theme = useTheme();
   const isTablet = useMediaQuery(theme.breakpoints.down("md"));
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));

--- a/src/components/modal/modals/IncompleteWarbandWarningModal.tsx
+++ b/src/components/modal/modals/IncompleteWarbandWarningModal.tsx
@@ -1,11 +1,13 @@
 import { Button, DialogActions, DialogContent } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import Typography from "@mui/material/Typography";
+import { useAppState } from "../../../state/app";
 import { useStore } from "../../../state/store.ts";
 import { isDefinedUnit } from "../../../types/unit.ts";
 
 export const IncompleteWarbandWarningModal = () => {
-  const { roster, closeModal, startNewGame } = useStore();
+  const { roster, startNewGame } = useStore();
+  const { closeModal } = useAppState();
 
   const continueToGameMode = () => {
     startNewGame();

--- a/src/components/modal/modals/ModalRosterTable.tsx
+++ b/src/components/modal/modals/ModalRosterTable.tsx
@@ -16,7 +16,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import html2canvas from "html2canvas";
 import { useState } from "react";
 import { FaImage } from "react-icons/fa6";
-import { useStore } from "../../../state/store";
+import { useAppState } from "../../../state/app";
 import { RosterTableView } from "../../common/roster/TableView.tsx";
 import { RosterTextView } from "../../common/roster/TextView.tsx";
 import { CustomSwitch as Switch } from "../../common/switch/CustomSwitch.tsx";
@@ -27,7 +27,7 @@ after the user clicks the 'Roster Table' button. This component uses the full ro
 state variable (passed to it as an argument) to populate a table of the army. */
 
 export const ModalRosterTable = () => {
-  const { setCurrentModal, closeModal } = useStore();
+  const { setCurrentModal, closeModal } = useAppState();
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));

--- a/src/components/modal/modals/ProfileCardModal.tsx
+++ b/src/components/modal/modals/ProfileCardModal.tsx
@@ -3,14 +3,14 @@ import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
 import { Fragment } from "react";
 import hero_constraint_data from "../../../assets/data/hero_constraint_data.json";
-import { useStore } from "../../../state/store.ts";
+import { useAppState } from "../../../state/app";
 import { Unit } from "../../../types/unit.ts";
 import { UnitProfileCard } from "../../common/images/UnitProfileCard.tsx";
 
 export const ProfileCardModal = () => {
   const {
     modalContext: { unitData },
-  } = useStore();
+  } = useAppState();
   const { palette } = useTheme();
 
   const ExtraProfileCards = ({ unit }: { unit: Unit }) => {

--- a/src/components/modal/modals/ResetGameModeModal.tsx
+++ b/src/components/modal/modals/ResetGameModeModal.tsx
@@ -1,8 +1,8 @@
-import { DialogActions, DialogContent, Button } from "@mui/material";
-import { useStore } from "../../../state/store.ts";
+import { Button, DialogActions, DialogContent } from "@mui/material";
+import { useAppState } from "../../../state/app";
 
 export const ResetGameModeModal = () => {
-  const { modalContext, closeModal } = useStore();
+  const { modalContext, closeModal } = useAppState();
 
   const handleContinue = () => {
     modalContext.handleReset();

--- a/src/components/modal/modals/ScreenshotRosterModal.tsx
+++ b/src/components/modal/modals/ScreenshotRosterModal.tsx
@@ -1,11 +1,11 @@
 import { ContentCopyOutlined, DownloadDoneOutlined } from "@mui/icons-material";
 import { Button, DialogActions, DialogContent } from "@mui/material";
 import Typography from "@mui/material/Typography";
-import { useStore } from "../../../state/store.ts";
+import { useAppState } from "../../../state/app";
 import { AlertTypes } from "../../alerts/alert-types.tsx";
 
 export const ScreenshotRosterModal = () => {
-  const { modalContext, triggerAlert, closeModal } = useStore();
+  const { modalContext, triggerAlert, closeModal } = useAppState();
 
   const supportsCopyImageToClipboard =
     navigator.clipboard && window.ClipboardItem;

--- a/src/hooks/external-storage.ts
+++ b/src/hooks/external-storage.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 import rawData from "../assets/data/mesbg_data.json";
 import { AlertTypes } from "../components/alerts/alert-types.tsx";
+import { useAppState } from "../state/app";
 import {
   handleAzog,
   handleMahudChief,
@@ -14,13 +15,9 @@ import { isDefinedUnit, Option, Unit } from "../types/unit.ts";
 import { useJsonValidation } from "./json-validation.ts";
 
 export const useExternalStorage = () => {
-  const {
-    roster,
-    triggerAlert,
-    setRoster,
-    updateBuilderSidebar,
-    factionSelection,
-  } = useStore();
+  const { roster, setRoster, updateBuilderSidebar, factionSelection } =
+    useStore();
+  const { triggerAlert } = useAppState();
   const { validateKeys } = useJsonValidation();
 
   const copyRosterToClipboard = () => {

--- a/src/state/Slice.ts
+++ b/src/state/Slice.ts
@@ -1,0 +1,9 @@
+import { StateCreator } from "zustand";
+
+export type Slice<S, SR> = StateCreator<
+  S,
+  | [["zustand/devtools", unknown]]
+  | [["zustand/devtools", unknown], ["zustand/persist", unknown]],
+  [],
+  SR
+>;

--- a/src/state/app/alert/index.ts
+++ b/src/state/app/alert/index.ts
@@ -1,5 +1,6 @@
-import { AlertTypes } from "../../components/alerts/alert-types.tsx";
-import { Slice } from "../store.ts";
+import { AlertTypes } from "../../../components/alerts/alert-types.tsx";
+import { Slice } from "../../Slice.ts";
+import { ApplicationState } from "../index.ts";
 
 export type AlertState = {
   activeAlert: AlertTypes | null;
@@ -11,7 +12,7 @@ const initialState = {
   activeAlert: null,
 };
 
-export const alertSlice: Slice<AlertState> = (set) => ({
+export const alertSlice: Slice<ApplicationState, AlertState> = (set) => ({
   ...initialState,
 
   triggerAlert: (alert) =>

--- a/src/state/app/index.ts
+++ b/src/state/app/index.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { alertSlice, AlertState } from "./alert";
+import { modalSlice, ModalState } from "./modal";
+import { sidebarSlice, SidebarState } from "./sidebar";
+
+export type ApplicationState = ModalState & SidebarState & AlertState;
+
+export const useAppState = create<
+  ApplicationState,
+  [["zustand/devtools", unknown]]
+>(
+  devtools((...args) => ({
+    ...modalSlice(...args),
+    ...sidebarSlice(...args),
+    ...alertSlice(...args),
+  })),
+);

--- a/src/state/app/modal/index.ts
+++ b/src/state/app/modal/index.ts
@@ -1,5 +1,6 @@
-import { ModalTypes } from "../../components/modal/modals.tsx";
-import { Slice } from "../store.ts";
+import { ModalTypes } from "../../../components/modal/modals.tsx";
+import { Slice } from "../../Slice.ts";
+import { ApplicationState } from "../index.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ModalContext = any;
@@ -16,7 +17,7 @@ const initialModalState = {
   modalContext: null,
 };
 
-export const modalSlice: Slice<ModalState> = (set) => ({
+export const modalSlice: Slice<ApplicationState, ModalState> = (set) => ({
   ...initialModalState,
 
   setCurrentModal: (modal, context) =>

--- a/src/state/app/sidebar/index.ts
+++ b/src/state/app/sidebar/index.ts
@@ -1,5 +1,6 @@
-import { DrawerTypes } from "../../components/drawer/drawers.tsx";
-import { Slice } from "../store.ts";
+import { DrawerTypes } from "../../../components/drawer/drawers.tsx";
+import { Slice } from "../../Slice.ts";
+import { ApplicationState } from "../index.ts";
 
 export type SidebarState = {
   currentlyOpenendSidebar: DrawerTypes | null;
@@ -11,7 +12,7 @@ const initialState = {
   currentlyOpenendSidebar: null,
 };
 
-export const sidebarSlice: Slice<SidebarState> = (set) => ({
+export const sidebarSlice: Slice<ApplicationState, SidebarState> = (set) => ({
   ...initialState,
 
   openSidebar: (sidebar) =>

--- a/src/state/builder-selection/index.ts
+++ b/src/state/builder-selection/index.ts
@@ -1,5 +1,6 @@
 import { Faction, Factions } from "../../types/factions.ts";
-import { Slice } from "../store.ts";
+import { Slice } from "../Slice.ts";
+import { AppState } from "../store.ts";
 
 export type Tabs = "Good Army" | "Evil Army" | "Good LL" | "Evil LL";
 
@@ -30,7 +31,7 @@ export const initialBuilderState: BuilderSelectionState = {
   warriorSelectionFocus: ["", ""],
 };
 
-export const builderSlice: Slice<BuilderState> = (set) => ({
+export const builderSlice: Slice<AppState, BuilderState> = (set) => ({
   ...initialBuilderState,
 
   updateBuilderSidebar: (update) =>

--- a/src/state/drag-and-drop/index.ts
+++ b/src/state/drag-and-drop/index.ts
@@ -1,5 +1,6 @@
 import { FreshUnit, Unit } from "../../types/unit.ts";
-import { Slice } from "../store.ts";
+import { Slice } from "../Slice.ts";
+import { AppState } from "../store.ts";
 
 export type DragAndDropState = {
   draggedUnit: Unit | FreshUnit | null;
@@ -11,7 +12,7 @@ const initialState = {
   draggedUnit: null,
 };
 
-export const dragAndDropSlice: Slice<DragAndDropState> = (set) => ({
+export const dragAndDropSlice: Slice<AppState, DragAndDropState> = (set) => ({
   ...initialState,
 
   setDraggedUnit: (unit) =>

--- a/src/state/gamemode/index.ts
+++ b/src/state/gamemode/index.ts
@@ -1,5 +1,6 @@
 import { GameModeHero } from "../../components/gamemode/types.ts";
-import { Slice } from "../store.ts";
+import { Slice } from "../Slice.ts";
+import { AppState } from "../store.ts";
 import { createGameState } from "./gamemode.ts";
 
 export type GameState = {
@@ -21,7 +22,7 @@ const initialState = {
   gameState: null,
 };
 
-export const gamemodeSlice: Slice<GamemodeState> = (set) => ({
+export const gamemodeSlice: Slice<AppState, GamemodeState> = (set) => ({
   ...initialState,
 
   setGameMode: (gameMode) => set({ gameMode }, undefined, "SET_GAME_MODE"),

--- a/src/state/roster/index.ts
+++ b/src/state/roster/index.ts
@@ -3,7 +3,8 @@ import { AllianceLevel } from "../../constants/alliances.ts";
 import { Faction, FactionType } from "../../types/factions.ts";
 import { Roster } from "../../types/roster.ts";
 import { FreshUnit, Unit } from "../../types/unit.ts";
-import { Slice } from "../store.ts";
+import { Slice } from "../Slice.ts";
+import { AppState } from "../store.ts";
 import {
   addWarband,
   assignHero,
@@ -78,7 +79,7 @@ const initialState = {
   rosterBuildingWarnings: [],
 };
 
-export const rosterSlice: Slice<RosterState> = (set, get) => {
+export const rosterSlice: Slice<AppState, RosterState> = (set, get) => {
   const recalculate = () => updateMetaData(set);
   return {
     ...initialState,

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,28 +1,15 @@
-import { create, StateCreator } from "zustand";
+import { create } from "zustand";
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
-import { alertSlice, AlertState } from "./alert";
 import { builderSlice, BuilderState } from "./builder-selection";
 import { dragAndDropSlice, DragAndDropState } from "./drag-and-drop";
 import { gamemodeSlice, GamemodeState } from "./gamemode";
-import { modalSlice, ModalState } from "./modal";
 import { getStateToPersist } from "./persistence.ts";
 import { rosterSlice, RosterState } from "./roster";
-import { sidebarSlice, SidebarState } from "./sidebar";
 
 export type AppState = RosterState &
   GamemodeState &
-  ModalState &
-  SidebarState &
-  AlertState &
   BuilderState &
   DragAndDropState;
-
-export type Slice<T> = StateCreator<
-  AppState,
-  [["zustand/devtools", unknown], ["zustand/persist", unknown]],
-  [],
-  T
->;
 
 export const useStore = create<
   AppState,
@@ -31,9 +18,6 @@ export const useStore = create<
   devtools(
     persist(
       (...args) => ({
-        ...modalSlice(...args),
-        ...sidebarSlice(...args),
-        ...alertSlice(...args),
         ...gamemodeSlice(...args),
         ...rosterSlice(...args),
         ...builderSlice(...args),


### PR DESCRIPTION
This pull request contains the beginnings of the multiple persisted rosters (for #77) using separate stores. In this PR I moved the application store that handles displaying certain components (Modals, Alerts & Sidebars) into a separate store. 