### PR TITLE
Add the total amount of might to the roster info bars

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,6 @@
 {
   "main": {
+    "added": ["Added the sum of might for all heros in the roster info bar"],
     "bugfixes": [
       "Fix issue with enter or tab keys not triggering match tag creation on mobile browsers"
     ]

--- a/src/components/alerts/alerts/GameModeAlert.tsx
+++ b/src/components/alerts/alerts/GameModeAlert.tsx
@@ -15,6 +15,7 @@ export const GameModeAlert = () => {
       num_units: 0,
       points: 0,
       bow_count: 0,
+      might_total: 0,
       leader_warband_id: null,
       warbands: [],
     });

--- a/src/components/common/layout/Header.tsx
+++ b/src/components/common/layout/Header.tsx
@@ -64,11 +64,32 @@ const RosterInfoBar = () => {
           Break Point: <b>{breakPoint}</b>
         </Typography>
         {!isMobile && (
+          <>
+            <Typography variant="body1" component="div">
+              Bows: <b>{roster.bow_count}</b>
+            </Typography>
+            <Typography variant="body1" component="div">
+              Might: <b>{roster.might_total ?? "N/A"}</b>
+            </Typography>
+          </>
+        )}
+      </Stack>
+      {isMobile && (
+        <Stack
+          direction="row"
+          spacing={isMobile ? 2 : 4}
+          justifyContent="center"
+          textAlign="center"
+          flexWrap="wrap"
+        >
           <Typography variant="body1" component="div">
             Bows: <b>{roster.bow_count}</b>
           </Typography>
-        )}
-      </Stack>
+          <Typography variant="body1" component="div">
+            Might: <b>{roster.might_total ?? "N/A"}</b>
+          </Typography>
+        </Stack>
+      )}
     </Box>
   );
 };
@@ -246,21 +267,23 @@ export const Header = () => {
               />
             </ListItem>
             <Divider sx={{ m: 2 }} />
-            {buttons.map((button, index) => (
-              <Fragment key={index}>
-                <ListItemButton onClick={button.onClick}>
-                  {button.icon && (
-                    <ListItemIcon sx={{ color: "white" }}>
-                      {button.icon}
-                    </ListItemIcon>
-                  )}
-                  <ListItemText
-                    primaryTypographyProps={{ fontSize: "1.4rem" }}
-                    primary={button.label}
-                  />
-                </ListItemButton>
-              </Fragment>
-            ))}
+            {buttons
+              .filter((button) => button.visible)
+              .map((button, index) => (
+                <Fragment key={index}>
+                  <ListItemButton onClick={button.onClick}>
+                    {button.icon && (
+                      <ListItemIcon sx={{ color: "white" }}>
+                        {button.icon}
+                      </ListItemIcon>
+                    )}
+                    <ListItemText
+                      primaryTypographyProps={{ fontSize: "1.4rem" }}
+                      primary={button.label}
+                    />
+                  </ListItemButton>
+                </Fragment>
+              ))}
           </List>
         </Box>
       </Drawer>

--- a/src/components/common/roster/TableView.tsx
+++ b/src/components/common/roster/TableView.tsx
@@ -143,7 +143,13 @@ export function RosterTableView({
         alignItems={isMobile && !screenshotting ? "start" : "center"}
       >
         <Typography flexGrow={1}>
-          Alliance level:
+          <Typography
+            sx={{
+              wordBreak: "keep-all",
+            }}
+          >
+            Alliance level:
+          </Typography>
           <Typography
             variant="body2"
             component="span"
@@ -169,10 +175,13 @@ export function RosterTableView({
           Total Units: <b>{roster.num_units}</b>
         </Typography>
         <Typography>
+          Break Point: <b>{Math.round(0.5 * roster.num_units * 100) / 100}</b>
+        </Typography>
+        <Typography>
           Total Bows: <b>{roster.bow_count}</b>
         </Typography>
         <Typography>
-          Break Point: <b>{Math.round(0.5 * roster.num_units * 100) / 100}</b>
+          Total Might: <b>{roster.might_total ?? "N/A"}</b>
         </Typography>
       </Stack>
       <TableContainer component={Paper} sx={{ mb: 2 }}>

--- a/src/components/common/roster/TextView.tsx
+++ b/src/components/common/roster/TextView.tsx
@@ -102,7 +102,7 @@ export function RosterTextView({
           .join("  \n");
 
     return `
-    | Total Points: ${roster.points} | Total Units: ${roster.num_units} | Break Point: ${Math.round(0.5 * roster.num_units * 100) / 100} |
+    | Total Points: ${roster.points} | Total Units: ${roster.num_units} | Break Point: ${Math.round(0.5 * roster.num_units * 100) / 100} | Total Bows ${roster.bow_count} | Total Might ${roster.might_total} |
     
     Alliance Level: ${allianceLevel}
     

--- a/src/state/roster-building/roster/actions/extra-roster-info.ts
+++ b/src/state/roster-building/roster/actions/extra-roster-info.ts
@@ -13,6 +13,7 @@ import {
 import {
   calculateAllianceLevel,
   calculateModelCount,
+  calculateRosterMightTotal,
   getFactionList,
   getFactionSpecialRules,
   getFactionType,
@@ -85,6 +86,7 @@ export const updateUnitCount = (roster: Roster) => {
     ...roster,
     num_units: calculateRosterUnitCount(roster),
     bow_count: calculateRosterTotalBowCount(roster),
+    might_total: calculateRosterMightTotal(roster),
     warbands: roster.warbands.map((warband) => ({
       ...warband,
       num_units: calculateWarbandModelCount(warband),

--- a/src/state/roster-building/roster/calculations/hero-special-stuff.ts
+++ b/src/state/roster-building/roster/calculations/hero-special-stuff.ts
@@ -1,7 +1,9 @@
 import hero_constraint_data from "../../../../assets/data/hero_constraint_data.json";
 import mesbg_data from "../../../../assets/data/mesbg_data.json";
+import { Roster } from "../../../../types/roster.ts";
 import { FreshUnit, isDefinedUnit, Unit } from "../../../../types/unit.ts";
 import { Warband } from "../../../../types/warband.ts";
+import { sum } from "../../../../utils/utils.ts";
 
 const handleMultiWoundMountOption = (
   hero: Unit,
@@ -172,3 +174,14 @@ export const getSpecialArmyOption = (hero: Unit): string =>
   hasSpecialArmyOption(hero)
     ? hero_constraint_data[hero.model_id][0]["special_army_option"]
     : null;
+
+export const calculateRosterMightTotal = (roster: Roster) => {
+  return roster.warbands
+    .flatMap((warband) => [warband.hero, ...warband.units])
+    .filter(isDefinedUnit)
+    .filter((unit) => unit.MWFW.length > 0)
+    .flatMap((unit) => unit.MWFW)
+    .map((mwfw) => mwfw[1].split(":")[0])
+    .map(Number)
+    .reduce(sum, 0);
+};

--- a/src/state/roster-building/roster/index.ts
+++ b/src/state/roster-building/roster/index.ts
@@ -65,6 +65,7 @@ export const emptyRoster = {
   num_units: 0,
   points: 0,
   bow_count: 0,
+  might_total: 0,
   leader_warband_id: null,
   warbands: [],
 };

--- a/src/types/roster.ts
+++ b/src/types/roster.ts
@@ -6,5 +6,6 @@ export type Roster = {
   leader_warband_id: string | null;
   num_units: number;
   bow_count: number;
+  might_total: number;
   points: number;
 };


### PR DESCRIPTION
This PR adds the total amount of might shared over the roster to the info bar and the roster sharing view.

![image](https://github.com/user-attachments/assets/56e661b8-4908-4dd3-8192-fe0cfb13c7ec)
top bar on desktop

![image](https://github.com/user-attachments/assets/afb7c11e-0dbb-49f7-ba36-8f13f4e6722e)
top bar on mobile

![image](https://github.com/user-attachments/assets/f94903e9-2cea-48d4-bb13-d6a83ae3225b)
share table

resolves #89 
