### PR TITLE
Unit selection

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -44,5 +44,7 @@ module.exports = {
     "react-hooks/exhaustive-deps": "warn",
     "react/jsx-curly-brace-presence": "warn",
     "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off",
+    "react/display-name": "off",
   },
 };

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,7 +2,8 @@
   "main": {
     "added": [
       "Added a filter on the unit selector to search for the model you want to add",
-      "Added the sum of might for all heros in the roster info bar"
+      "Added the sum of might for all heros in the roster info bar",
+      "Added a collapse all button to the warbands"
     ],
     "bugfixes": [
       "Fix issue with enter or tab keys not triggering match tag creation on mobile browsers"

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,8 +2,8 @@
   "main": {
     "added": [
       "Added a filter on the unit selector to search for the model you want to add",
-      "Added the sum of might for all heros in the roster info bar",
-      "Added a collapse all button to the warbands"
+      "Added the total Might points for all heroes in the roster info bar",
+      "Added a collapse-all button to the warbands"
     ],
     "bugfixes": [
       "Fix issue with enter or tab keys not triggering match tag creation on mobile browsers"

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,9 @@
 {
   "main": {
-    "added": ["Added the sum of might for all heros in the roster info bar"],
+    "added": [
+      "Added a filter on the unit selector to search for the model you want to add",
+      "Added the sum of might for all heros in the roster info bar"
+    ],
     "bugfixes": [
       "Fix issue with enter or tab keys not triggering match tag creation on mobile browsers"
     ],

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -4,7 +4,11 @@
     "bugfixes": [
       "Fix issue with enter or tab keys not triggering match tag creation on mobile browsers"
     ],
-    "changed": ["Added Eowyn and Merry's individual profile cards to Dernhelm."]
+    "changed": [
+      "Added Eowyn and Merry's individual profile cards to Dernhelm.",
+      "Now opens the unit selector when a new warband is created to select the hero leading that warband",
+      "Now opens the unit selector when a new unit is added to immediately allow selecting the unit"
+    ]
   },
   "6.12": {
     "added": [

--- a/src/components/builder-mode/unit-selection/FactionTypeTab.tsx
+++ b/src/components/builder-mode/unit-selection/FactionTypeTab.tsx
@@ -1,4 +1,8 @@
+import ClearIcon from "@mui/icons-material/Clear";
+import { InputAdornment, TextField } from "@mui/material";
+import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
+import { ChangeEvent, useEffect, useState } from "react";
 import { useRosterBuildingState } from "../../../state/roster-building";
 import { Tabs } from "../../../state/roster-building/builder-selection";
 import { FactionType } from "../../../types/factions.ts";
@@ -15,6 +19,16 @@ export function FactionTypeTab({
   activeTab: Tabs;
 }) {
   const { heroSelection, factionSelection } = useRosterBuildingState();
+  const [filterValue, setFilterValue] = useState("");
+
+  useEffect(() => {
+    setFilterValue("");
+  }, [heroSelection, factionSelection]);
+
+  const handleClear = () => {
+    setFilterValue("");
+  };
+
   return (
     <div
       role="tabpanel"
@@ -24,12 +38,35 @@ export function FactionTypeTab({
     >
       <Stack spacing={1} sx={{ mt: 1 }}>
         <FactionPickerDropdown type={type} />
+        <TextField
+          id="selection-filter"
+          label="Filter"
+          size="small"
+          value={filterValue}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            setFilterValue(event.target.value);
+          }}
+          slotProps={{
+            input: {
+              endAdornment: filterValue && (
+                <InputAdornment position="end">
+                  <IconButton onClick={handleClear} edge="end">
+                    <ClearIcon />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
         {heroSelection ? (
-          <HeroSelectionList faction={factionSelection[type]} />
+          <HeroSelectionList
+            faction={factionSelection[type]}
+            filter={filterValue}
+          />
         ) : (
           <>
-            <WarriorSelectionList />
-            <SiegeEquipmentSelectionList />
+            <WarriorSelectionList filter={filterValue} />
+            <SiegeEquipmentSelectionList filter={filterValue} />
           </>
         )}
       </Stack>

--- a/src/components/builder-mode/unit-selection/selection-list/HeroSelectionList.tsx
+++ b/src/components/builder-mode/unit-selection/selection-list/HeroSelectionList.tsx
@@ -23,7 +23,9 @@ export const HeroSelectionList: FunctionComponent<HeroSelectionListProps> = ({
         .filter(
           (hero) => !(hero.unique && uniqueModels.includes(hero.model_id)),
         )
-        .filter((hero) => hero.name.includes(filter))
+        .filter((unit) =>
+          unit.name.toLowerCase().includes(filter?.toLowerCase()),
+        )
         .map((hero) => (
           <UnitSelectionButton key={uuid()} unitData={hero} />
         ))}

--- a/src/components/builder-mode/unit-selection/selection-list/HeroSelectionList.tsx
+++ b/src/components/builder-mode/unit-selection/selection-list/HeroSelectionList.tsx
@@ -7,10 +7,12 @@ import { UnitSelectionButton } from "./UnitSelectionButton.tsx";
 
 type HeroSelectionListProps = {
   faction: Faction;
+  filter: string;
 };
 
 export const HeroSelectionList: FunctionComponent<HeroSelectionListProps> = ({
   faction,
+  filter,
 }) => {
   const { getHeroesFromFaction } = useMesbgData();
   const { uniqueModels } = useRosterBuildingState();
@@ -21,6 +23,7 @@ export const HeroSelectionList: FunctionComponent<HeroSelectionListProps> = ({
         .filter(
           (hero) => !(hero.unique && uniqueModels.includes(hero.model_id)),
         )
+        .filter((hero) => hero.name.includes(filter))
         .map((hero) => (
           <UnitSelectionButton key={uuid()} unitData={hero} />
         ))}

--- a/src/components/builder-mode/unit-selection/selection-list/SiegeEquipmentSelectionList.tsx
+++ b/src/components/builder-mode/unit-selection/selection-list/SiegeEquipmentSelectionList.tsx
@@ -4,11 +4,18 @@ import Accordion from "@mui/material/Accordion";
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import { FunctionComponent } from "react";
 import siege_equipment from "../../../../assets/data/siege_equipment.json";
 import { useRosterBuildingState } from "../../../../state/roster-building";
 import { UnitProfilePicture } from "../../../common/images/UnitProfilePicture.tsx";
 
-export const SiegeEquipmentSelectionList = () => {
+type SiegeEquipmentSelectionListProps = {
+  filter: string;
+};
+
+export const SiegeEquipmentSelectionList: FunctionComponent<
+  SiegeEquipmentSelectionListProps
+> = ({ filter }) => {
   const { selectUnit, warriorSelectionFocus, updateBuilderSidebar } =
     useRosterBuildingState();
 
@@ -21,7 +28,11 @@ export const SiegeEquipmentSelectionList = () => {
     });
   };
 
-  return (
+  const equipment = siege_equipment.filter((equipment) =>
+    equipment.name.includes(filter),
+  );
+
+  return equipment.length > 0 ? (
     <Accordion>
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
@@ -36,7 +47,7 @@ export const SiegeEquipmentSelectionList = () => {
           the &apos;Sieges&apos; section of the main rulebook and the War in
           Rohan supplement book.
         </Typography>
-        {siege_equipment.map((data) => (
+        {equipment.map((data) => (
           <Button
             key={data.model_id}
             variant="outlined"
@@ -72,5 +83,7 @@ export const SiegeEquipmentSelectionList = () => {
         ))}
       </AccordionDetails>
     </Accordion>
+  ) : (
+    <></>
   );
 };

--- a/src/components/builder-mode/unit-selection/selection-list/SiegeEquipmentSelectionList.tsx
+++ b/src/components/builder-mode/unit-selection/selection-list/SiegeEquipmentSelectionList.tsx
@@ -28,8 +28,8 @@ export const SiegeEquipmentSelectionList: FunctionComponent<
     });
   };
 
-  const equipment = siege_equipment.filter((equipment) =>
-    equipment.name.includes(filter),
+  const equipment = siege_equipment.filter((unit) =>
+    unit.name.toLowerCase().includes(filter?.toLowerCase()),
   );
 
   return equipment.length > 0 ? (

--- a/src/components/builder-mode/unit-selection/selection-list/WarriorSelectionList.tsx
+++ b/src/components/builder-mode/unit-selection/selection-list/WarriorSelectionList.tsx
@@ -3,14 +3,22 @@ import { v4 as uuid } from "uuid";
 import { useMesbgData } from "../../../../hooks/mesbg-data.ts";
 import { UnitSelectionButton } from "./UnitSelectionButton.tsx";
 
-export const WarriorSelectionList: FunctionComponent = () => {
+type WarriorSelectionListProps = {
+  filter: string;
+};
+
+export const WarriorSelectionList: FunctionComponent<
+  WarriorSelectionListProps
+> = ({ filter }) => {
   const { getEligibleWarbandUnits } = useMesbgData();
 
   return (
     <>
-      {getEligibleWarbandUnits().map((row) => (
-        <UnitSelectionButton key={uuid()} unitData={row} />
-      ))}
+      {getEligibleWarbandUnits()
+        .filter((unit) => unit.name.includes(filter))
+        .map((row) => (
+          <UnitSelectionButton key={uuid()} unitData={row} />
+        ))}
     </>
   );
 };

--- a/src/components/builder-mode/unit-selection/selection-list/WarriorSelectionList.tsx
+++ b/src/components/builder-mode/unit-selection/selection-list/WarriorSelectionList.tsx
@@ -15,7 +15,9 @@ export const WarriorSelectionList: FunctionComponent<
   return (
     <>
       {getEligibleWarbandUnits()
-        .filter((unit) => unit.name.includes(filter))
+        .filter((unit) =>
+          unit.name.toLowerCase().includes(filter?.toLowerCase()),
+        )
         .map((row) => (
           <UnitSelectionButton key={uuid()} unitData={row} />
         ))}

--- a/src/components/builder-mode/warbands/Warband.tsx
+++ b/src/components/builder-mode/warbands/Warband.tsx
@@ -6,7 +6,7 @@ import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import Stack from "@mui/material/Stack";
 import { useTheme } from "@mui/material/styles";
-import { FunctionComponent, useEffect, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { useMesbgData } from "../../../hooks/mesbg-data.ts";
 import { useScrollToTop } from "../../../hooks/scroll-to.ts";
 import { useRosterBuildingState } from "../../../state/roster-building";
@@ -20,194 +20,210 @@ import { WarbandInfo } from "./WarbandInfo.tsx";
 
 type WarbandProps = {
   warband: WarbandType;
+  collapseAll: (collapsed: boolean) => void;
 };
 
-export const Warband: FunctionComponent<WarbandProps> = ({ warband }) => {
-  const { addUnit, updateBuilderSidebar, draggedUnit } =
-    useRosterBuildingState();
-  const { getEligibleWarbandUnitsForHero } = useMesbgData();
-  const [collapsed, setCollapsed] = useState(false);
-  const [dropzoneEnabled, setDropzoneEnabled] = useState(true);
-  const theme = useTheme();
-  const scrollToTop = useScrollToTop("sidebar");
+export type WarbandActions = {
+  collapseAll: (collapsed: boolean) => void;
+};
 
-  useEffect(() => {
-    if (
-      !draggedUnit ||
-      !isDefinedUnit(draggedUnit) ||
-      draggedUnit.unit_type === "Siege"
-    ) {
-      setDropzoneEnabled(true);
-      return;
-    }
+export const Warband = forwardRef<WarbandActions, WarbandProps>(
+  ({ warband, collapseAll }, ref) => {
+    const { addUnit, updateBuilderSidebar, draggedUnit } =
+      useRosterBuildingState();
+    const { getEligibleWarbandUnitsForHero } = useMesbgData();
+    const [collapsed, setCollapsed] = useState(false);
+    const [dropzoneEnabled, setDropzoneEnabled] = useState(true);
+    const theme = useTheme();
+    const scrollToTop = useScrollToTop("sidebar");
 
-    if (!isDefinedUnit(warband.hero)) {
-      setDropzoneEnabled(true);
-      return;
-    }
+    useEffect(() => {
+      if (
+        !draggedUnit ||
+        !isDefinedUnit(draggedUnit) ||
+        draggedUnit.unit_type === "Siege"
+      ) {
+        setDropzoneEnabled(true);
+        return;
+      }
 
-    setDropzoneEnabled(
-      getEligibleWarbandUnitsForHero(warband.hero, false)
-        .map((unit) => unit.model_id)
-        .includes(draggedUnit.model_id),
-    );
-  }, [draggedUnit, warband.hero, getEligibleWarbandUnitsForHero]);
+      if (!isDefinedUnit(warband.hero)) {
+        setDropzoneEnabled(true);
+        return;
+      }
 
-  const handleNewWarrior = () => {
-    const createdUnitId = addUnit(warband.id);
-    updateBuilderSidebar({
-      heroSelection: false,
-      warriorSelection: true,
-      warriorSelectionFocus: [warband.id, createdUnitId],
-    });
-    setTimeout(scrollToTop, null);
-  };
+      setDropzoneEnabled(
+        getEligibleWarbandUnitsForHero(warband.hero, false)
+          .map((unit) => unit.model_id)
+          .includes(draggedUnit.model_id),
+      );
+    }, [draggedUnit, warband.hero, getEligibleWarbandUnitsForHero]);
 
-  const isHeroWhoLeads = (hero: Unit): boolean => {
-    if (!isDefinedUnit(hero)) return false;
+    const handleNewWarrior = () => {
+      const createdUnitId = addUnit(warband.id);
+      updateBuilderSidebar({
+        heroSelection: false,
+        warriorSelection: true,
+        warriorSelectionFocus: [warband.id, createdUnitId],
+      });
+      setTimeout(scrollToTop, null);
+    };
 
-    if (
-      ["Independent Hero", "Independent Hero*", "Siege Engine"].includes(
-        hero.unit_type,
+    const isHeroWhoLeads = (hero: Unit): boolean => {
+      if (!isDefinedUnit(hero)) return false;
+
+      if (
+        ["Independent Hero", "Independent Hero*", "Siege Engine"].includes(
+          hero.unit_type,
+        )
       )
-    )
-      return false;
+        return false;
 
-    if (
-      [
-        "[erebor_reclaimed_(king_thorin)] iron_hills_chariot_(champions_of_erebor)",
-        "[desolator_of_the_north] smaug",
-      ].includes(hero.model_id)
-    )
-      return false;
+      if (
+        [
+          "[erebor_reclaimed_(king_thorin)] iron_hills_chariot_(champions_of_erebor)",
+          "[desolator_of_the_north] smaug",
+        ].includes(hero.model_id)
+      )
+        return false;
 
-    return true;
-  };
+      return true;
+    };
 
-  return (
-    <Card
-      variant="elevation"
-      elevation={3}
-      data-scroll-id={warband.id}
-      sx={{
-        backgroundColor: theme.palette.grey.A700,
-        p: 1,
-      }}
-    >
-      <Stack spacing={1}>
-        <WarbandInfo
-          warband={warband}
-          collapse={setCollapsed}
-          collapsed={collapsed}
-        />
+    useImperativeHandle(ref, () => ({
+      collapseAll: (collapsed: boolean) => setCollapsed(collapsed),
+    }));
 
-        <Box data-scroll-id={warband.hero?.id}>
-          {!isDefinedUnit(warband.hero) ? (
-            <ChooseHeroButton warbandId={warband.id} />
-          ) : (
-            <WarbandHero
-              warbandId={warband.id}
-              unit={warband.hero}
-              collapsed={collapsed}
-            />
-          )}
-        </Box>
+    return (
+      <Card
+        variant="elevation"
+        elevation={3}
+        data-scroll-id={warband.id}
+        sx={{
+          backgroundColor: theme.palette.grey.A700,
+          p: 1,
+        }}
+      >
+        <Stack spacing={1}>
+          <WarbandInfo
+            warband={warband}
+            collapse={setCollapsed}
+            collapseAll={collapseAll}
+            collapsed={collapsed}
+          />
 
-        <Droppable droppableId={warband.id} isDropDisabled={!dropzoneEnabled}>
-          {(provided, snapshot) => (
-            <Stack
-              ref={provided.innerRef}
-              {...provided.droppableProps}
-              spacing={1}
-              sx={
-                snapshot.isDraggingOver
-                  ? {
-                      backgroundColor: "#FFFFFF33",
-                      border: "1px dashed white",
-                      p: 1,
-                      transition: "padding 0.3s ease",
-                    }
-                  : {
-                      transition: "padding 0.3s ease",
-                    }
-              }
-            >
-              {warband.units
-                // Filters 'choose a warrior buttons if the warband is collapsed
-                .filter((unit) => !collapsed || isDefinedUnit(unit))
-                .map((unit, index) => (
-                  <Draggable key={unit.id} draggableId={unit.id} index={index}>
-                    {(provided, snapshot) => (
-                      <Box
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        data-scroll-id={unit.id}
-                      >
+          <Box data-scroll-id={warband.hero?.id}>
+            {!isDefinedUnit(warband.hero) ? (
+              <ChooseHeroButton warbandId={warband.id} />
+            ) : (
+              <WarbandHero
+                warbandId={warband.id}
+                unit={warband.hero}
+                collapsed={collapsed}
+              />
+            )}
+          </Box>
+
+          <Droppable droppableId={warband.id} isDropDisabled={!dropzoneEnabled}>
+            {(provided, snapshot) => (
+              <Stack
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+                spacing={1}
+                sx={
+                  snapshot.isDraggingOver
+                    ? {
+                        backgroundColor: "#FFFFFF33",
+                        border: "1px dashed white",
+                        p: 1,
+                        transition: "padding 0.3s ease",
+                      }
+                    : {
+                        transition: "padding 0.3s ease",
+                      }
+                }
+              >
+                {warband.units
+                  // Filters 'choose a warrior buttons if the warband is collapsed
+                  .filter((unit) => !collapsed || isDefinedUnit(unit))
+                  .map((unit, index) => (
+                    <Draggable
+                      key={unit.id}
+                      draggableId={unit.id}
+                      index={index}
+                    >
+                      {(provided, snapshot) => (
                         <Box
-                          sx={
-                            snapshot.isDragging
-                              ? {
-                                  p: 3,
-                                  transition: "padding 0.3s ease",
-                                }
-                              : {
-                                  transition: "padding 0.3s ease",
-                                }
-                          }
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          data-scroll-id={unit.id}
                         >
                           <Box
                             sx={
                               snapshot.isDragging
                                 ? {
-                                    transform: "rotate(1.5deg)",
-                                    boxShadow: "1rem 1rem 1rem #00000099",
-                                    transition:
-                                      "transform 0.3s ease, boxShadow 0.3s ease",
+                                    p: 3,
+                                    transition: "padding 0.3s ease",
                                   }
                                 : {
-                                    transition:
-                                      "transform 0.3s ease, boxShadow 0.3s ease",
+                                    transition: "padding 0.3s ease",
                                   }
                             }
                           >
-                            {!isDefinedUnit(unit) ? (
-                              <ChooseWarriorButton
-                                warbandId={warband.id}
-                                unit={unit}
-                              />
-                            ) : (
-                              <WarbandWarrior
-                                warbandId={warband.id}
-                                unit={unit}
-                                collapsed={collapsed}
-                              />
-                            )}
+                            <Box
+                              sx={
+                                snapshot.isDragging
+                                  ? {
+                                      transform: "rotate(1.5deg)",
+                                      boxShadow: "1rem 1rem 1rem #00000099",
+                                      transition:
+                                        "transform 0.3s ease, boxShadow 0.3s ease",
+                                    }
+                                  : {
+                                      transition:
+                                        "transform 0.3s ease, boxShadow 0.3s ease",
+                                    }
+                              }
+                            >
+                              {!isDefinedUnit(unit) ? (
+                                <ChooseWarriorButton
+                                  warbandId={warband.id}
+                                  unit={unit}
+                                />
+                              ) : (
+                                <WarbandWarrior
+                                  warbandId={warband.id}
+                                  unit={unit}
+                                  collapsed={collapsed}
+                                />
+                              )}
+                            </Box>
                           </Box>
                         </Box>
-                      </Box>
-                    )}
-                  </Draggable>
-                ))}
-              {provided.placeholder}
-            </Stack>
-          )}
-        </Droppable>
+                      )}
+                    </Draggable>
+                  ))}
+                {provided.placeholder}
+              </Stack>
+            )}
+          </Droppable>
 
-        <Collapse in={!collapsed}>
-          {isHeroWhoLeads(warband.hero) && (
-            <Button
-              onClick={() => handleNewWarrior()}
-              variant="contained"
-              color="primary"
-              fullWidth
-              endIcon={<AddIcon />}
-            >
-              Add Unit
-            </Button>
-          )}
-        </Collapse>
-      </Stack>
-    </Card>
-  );
-};
+          <Collapse in={!collapsed}>
+            {isHeroWhoLeads(warband.hero) && (
+              <Button
+                onClick={() => handleNewWarrior()}
+                variant="contained"
+                color="primary"
+                fullWidth
+                endIcon={<AddIcon />}
+              >
+                Add Unit
+              </Button>
+            )}
+          </Collapse>
+        </Stack>
+      </Card>
+    );
+  },
+);

--- a/src/components/builder-mode/warbands/Warband.tsx
+++ b/src/components/builder-mode/warbands/Warband.tsx
@@ -8,6 +8,7 @@ import Stack from "@mui/material/Stack";
 import { useTheme } from "@mui/material/styles";
 import { FunctionComponent, useEffect, useState } from "react";
 import { useMesbgData } from "../../../hooks/mesbg-data.ts";
+import { useScrollToTop } from "../../../hooks/scroll-to.ts";
 import { useRosterBuildingState } from "../../../state/roster-building";
 import { isDefinedUnit, Unit } from "../../../types/unit.ts";
 import { Warband as WarbandType } from "../../../types/warband.ts";
@@ -28,6 +29,7 @@ export const Warband: FunctionComponent<WarbandProps> = ({ warband }) => {
   const [collapsed, setCollapsed] = useState(false);
   const [dropzoneEnabled, setDropzoneEnabled] = useState(true);
   const theme = useTheme();
+  const scrollToTop = useScrollToTop("sidebar");
 
   useEffect(() => {
     if (
@@ -52,11 +54,13 @@ export const Warband: FunctionComponent<WarbandProps> = ({ warband }) => {
   }, [draggedUnit, warband.hero, getEligibleWarbandUnitsForHero]);
 
   const handleNewWarrior = () => {
-    addUnit(warband.id);
+    const createdUnitId = addUnit(warband.id);
     updateBuilderSidebar({
       heroSelection: false,
-      warriorSelection: false,
+      warriorSelection: true,
+      warriorSelectionFocus: [warband.id, createdUnitId],
     });
+    setTimeout(scrollToTop, null);
   };
 
   const isHeroWhoLeads = (hero: Unit): boolean => {

--- a/src/components/builder-mode/warbands/WarbandActions.tsx
+++ b/src/components/builder-mode/warbands/WarbandActions.tsx
@@ -1,4 +1,9 @@
-import { UnfoldLess, UnfoldMore } from "@mui/icons-material";
+import {
+  UnfoldLess,
+  UnfoldLessDouble,
+  UnfoldMore,
+  UnfoldMoreDouble,
+} from "@mui/icons-material";
 import CancelIcon from "@mui/icons-material/Cancel";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import IconButton from "@mui/material/IconButton";
@@ -12,10 +17,12 @@ export const WarbandActions = ({
   warband,
   collapsed,
   collapse,
+  collapseAll,
 }: {
   warband: Warband;
   collapsed: boolean;
   collapse: (collapsed: boolean) => void;
+  collapseAll: (collapsed: boolean) => void;
 }) => {
   const { duplicateWarband, deleteWarband, updateBuilderSidebar } =
     useRosterBuildingState();
@@ -83,6 +90,20 @@ export const WarbandActions = ({
         }}
       >
         {collapsed ? <UnfoldMore /> : <UnfoldLess />}
+      </IconButton>
+      <IconButton
+        onClick={() => collapseAll(!collapsed)}
+        aria-label="colapseAll"
+        sx={{
+          borderRadius: 2,
+          color: "white",
+          backgroundColor: palette.grey.A400,
+          "&:hover": {
+            backgroundColor: palette.grey.A700,
+          },
+        }}
+      >
+        {collapsed ? <UnfoldMoreDouble /> : <UnfoldLessDouble />}
       </IconButton>
     </Stack>
   );

--- a/src/components/builder-mode/warbands/WarbandInfo.tsx
+++ b/src/components/builder-mode/warbands/WarbandInfo.tsx
@@ -11,10 +11,12 @@ const MobileWarbandInfo = ({
   warband,
   collapsed,
   collapse,
+  collapseAll,
 }: {
   warband: Warband;
   collapsed: boolean;
   collapse: (collapsed: boolean) => void;
+  collapseAll: (collapsed: boolean) => void;
 }) => {
   return (
     <Stack direction="column" alignItems="center" spacing={2}>
@@ -32,6 +34,7 @@ const MobileWarbandInfo = ({
         <WarbandActions
           warband={warband}
           collapse={collapse}
+          collapseAll={collapseAll}
           collapsed={collapsed}
         />
       </Stack>
@@ -60,10 +63,12 @@ export const WarbandInfo = ({
   warband,
   collapsed,
   collapse,
+  collapseAll,
 }: {
   warband: Warband;
   collapsed: boolean;
   collapse: (collapsed: boolean) => void;
+  collapseAll?: (collapsed: boolean) => void;
 }) => {
   const theme = useTheme();
   const isTablet = useMediaQuery(theme.breakpoints.down("md"));
@@ -72,6 +77,7 @@ export const WarbandInfo = ({
     <MobileWarbandInfo
       warband={warband}
       collapse={collapse}
+      collapseAll={collapseAll}
       collapsed={collapsed}
     />
   ) : (
@@ -127,6 +133,7 @@ export const WarbandInfo = ({
       <WarbandActions
         warband={warband}
         collapse={collapse}
+        collapseAll={collapseAll}
         collapsed={collapsed}
       />
     </Stack>

--- a/src/components/builder-mode/warbands/Warbands.tsx
+++ b/src/components/builder-mode/warbands/Warbands.tsx
@@ -2,6 +2,7 @@ import { DragDropContext, DragStart, DropResult } from "@hello-pangea/dnd";
 import AddIcon from "@mui/icons-material/Add";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import { useScrollToTop } from "../../../hooks/scroll-to.ts";
 import { useRosterBuildingState } from "../../../state/roster-building";
 import { moveItem, moveItemBetweenLists } from "../../../utils/array.ts";
 import { Warband } from "./Warband.tsx";
@@ -17,12 +18,16 @@ export const Warbands = () => {
     clearDraggedUnit,
     reorderUnits,
   } = useRosterBuildingState();
+  const scrollToTop = useScrollToTop("sidebar");
 
   const handleNewWarband = () => {
-    addWarband();
+    const createdWarbandId = addWarband();
     updateBuilderSidebar({
-      warriorSelection: false,
+      warriorSelection: true,
+      heroSelection: true,
+      warriorSelectionFocus: [createdWarbandId, null],
     });
+    setTimeout(scrollToTop, null);
   };
 
   const onDragStart = (x: DragStart) => {

--- a/src/components/builder-mode/warbands/Warbands.tsx
+++ b/src/components/builder-mode/warbands/Warbands.tsx
@@ -2,10 +2,11 @@ import { DragDropContext, DragStart, DropResult } from "@hello-pangea/dnd";
 import AddIcon from "@mui/icons-material/Add";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import { createRef, useEffect, useRef } from "react";
 import { useScrollToTop } from "../../../hooks/scroll-to.ts";
 import { useRosterBuildingState } from "../../../state/roster-building";
 import { moveItem, moveItemBetweenLists } from "../../../utils/array.ts";
-import { Warband } from "./Warband.tsx";
+import { Warband, WarbandActions } from "./Warband.tsx";
 
 /* Displays the list of all warbands, and also defines how each warband card looks. */
 
@@ -19,6 +20,15 @@ export const Warbands = () => {
     reorderUnits,
   } = useRosterBuildingState();
   const scrollToTop = useScrollToTop("sidebar");
+
+  const refs = useRef(roster.warbands.map(() => createRef<WarbandActions>()));
+
+  useEffect(() => {
+    // Adjust the refs array when the warbands get updated.
+    refs.current = roster.warbands.map(
+      (_, i) => refs.current[i] || createRef<WarbandActions>(),
+    );
+  }, [roster.warbands]);
 
   const handleNewWarband = () => {
     const createdWarbandId = addWarband();
@@ -80,11 +90,22 @@ export const Warbands = () => {
     clearDraggedUnit();
   };
 
+  const collapseAll = (collapsed: boolean) => {
+    refs.current.forEach((ref) => {
+      ref.current.collapseAll(collapsed);
+    });
+  };
+
   return (
     <Stack spacing={1} sx={{ pb: 16 }}>
       <DragDropContext onDragEnd={updateRoster} onDragStart={onDragStart}>
-        {roster.warbands.map((warband) => (
-          <Warband key={warband.id} warband={warband} />
+        {roster.warbands.map((warband, index) => (
+          <Warband
+            key={warband.id}
+            warband={warband}
+            ref={refs.current[index]}
+            collapseAll={collapseAll}
+          />
         ))}
       </DragDropContext>
       <Button

--- a/src/components/common/game-results-form/GameResultsForm.tsx
+++ b/src/components/common/game-results-form/GameResultsForm.tsx
@@ -62,7 +62,6 @@ export type GameResultsFormHandlers = {
   saveToState: () => boolean;
 };
 
-// eslint-disable-next-line react/display-name
 export const GameResultsForm = forwardRef<GameResultsFormHandlers>((_, ref) => {
   const { modalContext } = useAppState();
   const { addGame, editGame } = useRecentGamesState();

--- a/src/state/roster-building/roster/actions/warband.ts
+++ b/src/state/roster-building/roster/actions/warband.ts
@@ -10,10 +10,10 @@ import {
 import { RosterState } from "../index.ts";
 
 export const addWarband =
-  () =>
+  (newWarbandId: string) =>
   ({ roster }: RosterBuildingState) => {
     roster.warbands.push({
-      id: uuid(),
+      id: newWarbandId,
       num: roster.warbands.length + 1,
       points: 0,
       num_units: 0,

--- a/src/state/roster-building/roster/index.ts
+++ b/src/state/roster-building/roster/index.ts
@@ -29,7 +29,7 @@ type RosterFunctions = {
   setRoster: (roster: Roster) => void;
 
   // Global warband functions
-  addWarband: () => void;
+  addWarband: () => string;
   deleteWarband: (warbandId: string) => void;
   duplicateWarband: (warbandId: string) => string;
 
@@ -40,7 +40,7 @@ type RosterFunctions = {
   makeLeader: (warbandId: string) => void;
 
   // Unit functions
-  addUnit: (warbandId: string) => void;
+  addUnit: (warbandId: string) => string;
   selectUnit: (warbandId: string, unitId: string, unit: Unit) => void;
   updateUnit: (warbandId: string, unitId: string, unit: Partial<Unit>) => void;
   deleteUnit: (warbandId: string, unitId: string) => void;
@@ -108,7 +108,11 @@ export const rosterSlice: Slice<RosterBuildingState, RosterState> = (
       recalculate();
     },
 
-    addWarband: (): void => set(addWarband(), undefined, "ADD_WARBAND"),
+    addWarband: (): string => {
+      const newWarbandId = uuid();
+      set(addWarband(newWarbandId), undefined, "ADD_WARBAND");
+      return newWarbandId;
+    },
     duplicateWarband: (warbandId: string): string => {
       set(duplicateWarband(warbandId), undefined, "DUPLICATE_WARBAND");
       recalculate();
@@ -144,18 +148,21 @@ export const rosterSlice: Slice<RosterBuildingState, RosterState> = (
       recalculate();
     },
 
-    addUnit: (warbandId: string): void =>
+    addUnit: (warbandId: string): string => {
+      const newUnitId = uuid();
       set(
         ({ roster }) => {
           const warband = roster.warbands.find(({ id }) => id === warbandId);
-          warband.units.push({ id: uuid(), name: null } as FreshUnit);
+          warband.units.push({ id: newUnitId, name: null } as FreshUnit);
           return {
             roster,
           };
         },
         undefined,
         "ADD_UNIT",
-      ),
+      );
+      return newUnitId;
+    },
     selectUnit: (warbandId: string, unitId: string, unit: Unit): void => {
       set(selectUnit(warbandId, unitId, unit), undefined, "SELECT_UNIT");
       recalculate();


### PR DESCRIPTION
This PR resolves the issues #87 and #88 

When clicking on add unit or add warband it automatically opens the unit selector allowing you to select a hero (for warband creation) or the unit you were about to add. This reduces 1 click on the "Choose a X" button.
resolves #88 

I also added a search input on the top of the unit selector allowing to search down in the list of units. 
resolves #87 

![image](https://github.com/user-attachments/assets/1cf15439-eaa5-4832-af97-2ea0b0250943)


resolves #91 

![image](https://github.com/user-attachments/assets/b7eb06ee-6af8-4fb4-9ab2-e396c4aa2fc7)
